### PR TITLE
Display microphone session

### DIFF
--- a/AirCasting/CoreData/AirCasting.xcdatamodeld/AirCasting.xcdatamodel/contents
+++ b/AirCasting/CoreData/AirCasting.xcdatamodeld/AirCasting.xcdatamodel/contents
@@ -36,7 +36,7 @@
     <entity name="Session" representedClassName="Session" syncable="YES">
         <attribute name="contribute" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="deviceId" optional="YES" attributeType="String"/>
-        <attribute name="deviceType" optional="YES" attributeType="Integer 16" usesScalarValueType="YES"/>
+        <attribute name="deviceType" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="endTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="followedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="gotDeleted" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>

--- a/AirCasting/CoreData/AirCasting.xcdatamodeld/AirCasting.xcdatamodel/contents
+++ b/AirCasting/CoreData/AirCasting.xcdatamodeld/AirCasting.xcdatamodel/contents
@@ -36,7 +36,7 @@
     <entity name="Session" representedClassName="Session" syncable="YES">
         <attribute name="contribute" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="deviceId" optional="YES" attributeType="String"/>
-        <attribute name="deviceType" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="deviceType" optional="YES" attributeType="Integer 16" usesScalarValueType="YES"/>
         <attribute name="endTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="followedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="gotDeleted" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>

--- a/AirCasting/CreateSessionViews/SelectDeviceView.swift
+++ b/AirCasting/CreateSessionViews/SelectDeviceView.swift
@@ -16,6 +16,7 @@ struct SelectDeviceView: View {
     @State private var isMicLinkActive: Bool = false
     @EnvironmentObject private var sessionContext: CreateSessionContext
     @EnvironmentObject var bluetoothManager: BluetoothManager
+    @EnvironmentObject private var microphoneManager: MicrophoneManager
     
     var body: some View {
         VStack(spacing: 30) {
@@ -57,6 +58,7 @@ struct SelectDeviceView: View {
             micLabels
         })
         .buttonStyle(WhiteSelectingButtonStyle(isSelected: selected == 2))
+        .disabled(microphoneManager.isRecording)
     }
     
     var bluetoothLabels: some View {

--- a/AirCasting/MicrophoneSession/MicrophoneManager.swift
+++ b/AirCasting/MicrophoneSession/MicrophoneManager.swift
@@ -87,8 +87,6 @@ class MicrophoneManager: ObservableObject {
         
         measurementStream?.addToMeasurements(measurement)
         
-        print(measurement)
-        
         do {
             try context.save()
         } catch {

--- a/AirCasting/MicrophoneSession/MicrophoneManager.swift
+++ b/AirCasting/MicrophoneSession/MicrophoneManager.swift
@@ -17,19 +17,24 @@ class MicrophoneManager: ObservableObject {
     var session: Session?
     var measurementStream: MeasurementStream?
     
+    //This variable is used to block recording more than one microphone session at a time
+    var isRecording = false
+    
     private var recorder: AVAudioRecorder!
     private var levelTimer = Timer()
     
     private var locationProvider = LocationProvider()
     
     func startRecording(session: Session) {
+        if isRecording { return }
+        
         let audioSession = AVAudioSession.sharedInstance()
         
         //Check microphone permisson
         if audioSession.recordPermission != .granted {
             audioSession.requestRecordPermission { (isGranted) in
                 if !isGranted {
-                    // TODO: pop-up that informs user that we need access to mic with ability do go back to homescreen
+                    //TODO: pop-up that informs user that we need access to mic with ability do go back to homescreen
                     fatalError("You must allow audio recording for this demo to work")
                 }
             }
@@ -59,6 +64,7 @@ class MicrophoneManager: ObservableObject {
         
         recorder.isMeteringEnabled = true
         recorder.record()
+        isRecording = true
         
         levelTimer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(getMeasurement), userInfo: nil, repeats: true)
     }
@@ -92,6 +98,7 @@ class MicrophoneManager: ObservableObject {
     
     func stopRecording() {
         levelTimer.invalidate()
+        isRecording = false
     }
     
     private

--- a/AirCasting/Models/SessionContext.swift
+++ b/AirCasting/Models/SessionContext.swift
@@ -20,7 +20,7 @@ class CreateSessionContext: ObservableObject {
     var wifiPassword: String?
     var isIndoor: Bool?
     var startingLocation: CLLocationCoordinate2D?
-    var deviceType: DeviceType?
+    var deviceType: DeviceType = DeviceType.AIRBEAM3 // It is set here temporarily to fix bug with fixed sessions
 
     var managedObjectContext: NSManagedObjectContext?
     private var syncSink: Any?
@@ -41,7 +41,7 @@ class CreateSessionContext: ObservableObject {
     func setupAB() {
         guard let managedObjectContext = managedObjectContext,
               let sessionType = sessionType,
-              let deviceType = deviceType,
+//              let deviceType = deviceType,
               let startingLocation = startingLocation else { return }
         
         // Save data to app's database
@@ -110,7 +110,7 @@ class CreateSessionContext: ObservableObject {
     func startMicrophoneSession(microphoneManager: MicrophoneManager){
         guard let managedObjectContext = managedObjectContext,
               let sessionType = sessionType,
-              let deviceType = deviceType,
+//              let deviceType = deviceType,
               let startingLocation = startingLocation else { return }
         
         // Save data to app's database

--- a/AirCasting/Models/SessionContext.swift
+++ b/AirCasting/Models/SessionContext.swift
@@ -124,8 +124,6 @@ class CreateSessionContext: ObservableObject {
         session.longitude = startingLocation.longitude
         session.latitude = startingLocation.latitude
         
-        print(session)
-        
         microphoneManager.startRecording(session: session)
     }
     

--- a/AirCasting/Models/SessionExtension.swift
+++ b/AirCasting/Models/SessionExtension.swift
@@ -45,4 +45,11 @@ extension Session {
         let HStream = matach as? MeasurementStream
         return HStream
     }
+    var dbStream: MeasurementStream? {
+        let matach = measurementStreams?.first(where: { (stream) -> Bool in
+            (stream as? MeasurementStream)?.measurementShortType == "db"
+        })
+        let dbStream = matach as? MeasurementStream
+        return dbStream
+    }
 }

--- a/AirCasting/SessionViews/SessionHeaderView.swift
+++ b/AirCasting/SessionViews/SessionHeaderView.swift
@@ -13,12 +13,16 @@ struct SessionHeaderView: View {
     let action: () -> Void
     let isExpandButtonNeeded: Bool
     @ObservedObject var session: Session
-        
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 13){
             dateAndTime
             nameLabelAndExpandButton
-            measurements
+            if (session.deviceType == DeviceType.MIC.rawValue) {
+                measurementsMic
+            } else {
+                measurementsAB
+            }
         }
         .font(Font.moderate(size: 13, weight: .regular))
         .foregroundColor(.aircastingGray)
@@ -64,8 +68,8 @@ struct SessionHeaderView: View {
     var measurementsTitle: some View {
         Text("Most recent measurement:")
     }
-        
-    var measurements: some View {
+    
+    var measurementsAB: some View {
         Group {
             if let measurements = extractLatestMeasurements() {
                 VStack(alignment: .leading, spacing: 5) {
@@ -90,6 +94,13 @@ struct SessionHeaderView: View {
                 }
                 .foregroundColor(.darkBlue)
             }
+        }
+    }
+    
+    var measurementsMic: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            measurementsTitle
+            singleMeasurement(name: "db", value: lastMicMeasurement())
         }
     }
     
@@ -132,6 +143,11 @@ struct SessionHeaderView: View {
             return nil
         }
     }
+    
+    func lastMicMeasurement() -> Int {
+        return Int(session.dbStream?.latestValue ?? 0)
+    }
+    
     func showSessionType() -> String {
         if session.type == SessionType.FIXED.rawValue {
             return "Fixed"

--- a/AirCasting/SessionViews/SessionHeaderView.swift
+++ b/AirCasting/SessionViews/SessionHeaderView.swift
@@ -13,13 +13,18 @@ struct SessionHeaderView: View {
     let action: () -> Void
     let isExpandButtonNeeded: Bool
     @ObservedObject var session: Session
+    @EnvironmentObject private var microphoneManager: MicrophoneManager
     
     var body: some View {
         VStack(alignment: .leading, spacing: 13){
             dateAndTime
             nameLabelAndExpandButton
             if (session.deviceType == DeviceType.MIC.rawValue) {
-                measurementsMic
+                HStack {
+                    measurementsMic
+                    Spacer()
+                    stopRecordingButton //This is a temporary solution
+                }
             } else {
                 measurementsAB
             }
@@ -102,6 +107,15 @@ struct SessionHeaderView: View {
             measurementsTitle
             singleMeasurement(name: "db", value: lastMicMeasurement())
         }
+    }
+    
+    var stopRecordingButton: some View {
+        Button(action: {
+            microphoneManager.stopRecording()
+        }, label: {
+            Text("Stop recording")
+                .foregroundColor(.blue)
+        })
     }
     
     func singleMeasurement(name: String, value: Int) -> some View {

--- a/AirCasting/SessionViews/SessionHeaderView.swift
+++ b/AirCasting/SessionViews/SessionHeaderView.swift
@@ -23,7 +23,9 @@ struct SessionHeaderView: View {
                 HStack {
                     measurementsMic
                     Spacer()
-                    stopRecordingButton //This is a temporary solution
+                    if microphoneManager.isRecording {
+                        stopRecordingButton //This is a temporary solution
+                    }
                 }
             } else {
                 measurementsAB


### PR DESCRIPTION
# Summary

Data from microphone session gets displayed in dashboard in session cell. It is possible now to stop recording session and it is impossible to start recording another microphone session when the other one is still recording.

## Features
* Displaying measurements in sessionHeader
* Add button for stopping microphone session recording
* Prevent creating more than one microphone session