### PR TITLE
Fix microphone session flow

### DIFF
--- a/AirCasting.xcodeproj/project.pbxproj
+++ b/AirCasting.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		331EA80A25E32094009DEFDB /* ConfirmCreatingSessionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331EA80925E32094009DEFDB /* ConfirmCreatingSessionView.swift */; };
 		332F521425FA38430047236D /* MicrophoneManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332F521325FA38430047236D /* MicrophoneManager.swift */; };
+		3346F1F626318C1600BA4695 /* SettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3346F1F526318C1600BA4695 /* SettingsManager.swift */; };
 		3362B4ED25E69987008D61BA /* AddNameAndTagsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3362B4EC25E69987008D61BA /* AddNameAndTagsView.swift */; };
 		338C30E225F1044B00E0305C /* Persistance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 338C30E125F1044B00E0305C /* Persistance.swift */; };
 		338C30E825F10BFE00E0305C /* AirCasting.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 338C30E625F10BFE00E0305C /* AirCasting.xcdatamodeld */; };
@@ -129,6 +130,7 @@
 		278FFE79104B8F74B61CE3A2 /* Pods-AirCasting.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AirCasting.release.xcconfig"; path = "Target Support Files/Pods-AirCasting/Pods-AirCasting.release.xcconfig"; sourceTree = "<group>"; };
 		331EA80925E32094009DEFDB /* ConfirmCreatingSessionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmCreatingSessionView.swift; sourceTree = "<group>"; };
 		332F521325FA38430047236D /* MicrophoneManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrophoneManager.swift; sourceTree = "<group>"; };
+		3346F1F526318C1600BA4695 /* SettingsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsManager.swift; sourceTree = "<group>"; };
 		3362B4EC25E69987008D61BA /* AddNameAndTagsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddNameAndTagsView.swift; sourceTree = "<group>"; };
 		338C30E125F1044B00E0305C /* Persistance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Persistance.swift; sourceTree = "<group>"; };
 		338C30E725F10BFE00E0305C /* AirCasting.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = AirCasting.xcdatamodel; sourceTree = "<group>"; };
@@ -367,6 +369,7 @@
 				AC4EC6C025B6F18A00C1E312 /* EditButtonView.swift */,
 				AC8CFF4025E5095600FB2918 /* Textfield.swift */,
 				ACD01F942600A54400B8F65F /* UserDefaults+Preferences.swift */,
+				3346F1F526318C1600BA4695 /* SettingsManager.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -881,6 +884,7 @@
 				AC524AAC2616003C0061AD45 /* DateFormatter.swift in Sources */,
 				AC93B8DA25BEDC46003D0A0D /* Array.swift in Sources */,
 				ACD01F7625FF61CE00B8F65F /* LocationProvider.swift in Sources */,
+				3346F1F626318C1600BA4695 /* SettingsManager.swift in Sources */,
 				AC7AB09225D988CD0025492B /* WhiteSelectingButtonStyle.swift in Sources */,
 				AC32041C25CC46EF00A68520 /* PowerABView.swift in Sources */,
 				AC86EE6B25D03DC00083F8C0 /* SelectDeviceView.swift in Sources */,

--- a/AirCasting/CreateSessionViews/SelectDeviceView.swift
+++ b/AirCasting/CreateSessionViews/SelectDeviceView.swift
@@ -93,7 +93,19 @@ struct SelectDeviceView: View {
                     isTurnOnBluetoothLinkActive = true
                 }
             } else if selected == 2 {
-                isMicLinkActive = true
+                if microphoneManager.recordPermissionGranted() {
+                    isMicLinkActive = true
+                } else {
+                    microphoneManager.requestRecordPermission { (isGranted) in
+                        DispatchQueue.main.async {
+                            if isGranted {
+                                isMicLinkActive = true
+                            } else {
+                                SettingsManager.goToAuthSettings()
+                            }
+                        }
+                    }
+                }
             }
         }, label: {
             Text("Choose")
@@ -113,7 +125,6 @@ struct SelectDeviceView: View {
                     EmptyView()
                 })
             NavigationLink(
-                // TO DO: change destination
                 destination: AddNameAndTagsView(),
                 isActive: $isMicLinkActive,
                 label: {

--- a/AirCasting/MicrophoneSession/MicrophoneManager.swift
+++ b/AirCasting/MicrophoneSession/MicrophoneManager.swift
@@ -1,8 +1,5 @@
 //
-//  microphoneManager.swift
-//  AirCasting
-//
-//  Created by Anna Olak on 11/03/2021.
+//  Created by Lunar on 11/03/2021.
 //
 
 import Foundation
@@ -11,120 +8,163 @@ import CoreAudio
 import CoreData
 
 class MicrophoneManager: ObservableObject {
+    static private let recordSettings: [String: Any] = [
+        AVFormatIDKey: NSNumber(value: kAudioFormatAppleLossless),
+        AVSampleRateKey: 44100.0,
+        AVNumberOfChannelsKey: 1,
+        AVEncoderAudioQualityKey: AVAudioQuality.min.rawValue
+    ]
+    
     var context: NSManagedObjectContext {
         PersistenceController.shared.container.viewContext
     }
-    var session: Session?
+    private var session: Session?
     var measurementStream: MeasurementStream?
+    
+    lazy var notificationCenter = NotificationCenter.default
     
     //This variable is used to block recording more than one microphone session at a time
     private(set) var isRecording = false
     
     private var recorder: AVAudioRecorder!
+    private(set) lazy var audioSession = AVAudioSession.sharedInstance()
+    //remove or use instead of the requestPermissionGranted function
+    var recordPermission: AVAudioSession.RecordPermission { audioSession.recordPermission }
     private var levelTimer = Timer()
     
     private var locationProvider = LocationProvider()
     
-    func startRecording(session: Session) {
+    func startRecording(session: Session) throws {
         if isRecording { return }
         
-        let audioSession = AVAudioSession.sharedInstance()
-        
-        //Check microphone permisson
         if audioSession.recordPermission != .granted {
-            audioSession.requestRecordPermission { (isGranted) in
-                if !isGranted {
-                    //TODO: pop-up that informs user that we need access to mic with ability do go back to homescreen
-                    fatalError("You must allow audio recording for this demo to work")
-                }
-            }
+            throw MicrophoneSessionError.permissionNotGranted
         }
         
+        addInterruptionsObserver()
+        
         self.session = session
-        createDBStream()
+        createDBStream(for: session)
         locationProvider.requestLocation()
         
         let url = URL(fileURLWithPath: "/dev/null", isDirectory: true)
         
-        let recordSettings: [String: Any] = [
-            AVFormatIDKey: NSNumber(value: kAudioFormatAppleLossless),
-            AVSampleRateKey: 44100.0,
-            AVNumberOfChannelsKey: 1,
-            AVEncoderAudioQualityKey: AVAudioQuality.min.rawValue
-        ]
+        try audioSession.setCategory(AVAudioSession.Category.playAndRecord)
+        try audioSession.setActive(true)
+        try recorder = AVAudioRecorder(url:url, settings: MicrophoneManager.recordSettings)
         
-        do {
-            try audioSession.setCategory(AVAudioSession.Category.playAndRecord)
-            try audioSession.setActive(true)
-            try recorder = AVAudioRecorder(url:url, settings: recordSettings)
-            
-        } catch {
-            return
-        }
         
         recorder.isMeteringEnabled = true
         recorder.record()
         isRecording = true
         
+        getMeasurement()
         levelTimer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(getMeasurement), userInfo: nil, repeats: true)
+        
     }
     
+    func stopRecording() throws {
+        levelTimer.invalidate()
+        removeInterruptionsObserver()
+        isRecording = false
+        recorder.stop()
+        recorder = nil
+        guard let session = session else {
+            throw MicrophoneSessionError.sessionNotSet
+        }
+        session.status = .FINISHED
+        try context.save()
+    }
+    
+    func recordPermissionGranted() -> Bool {
+        return audioSession.recordPermission == .granted
+    }
+    
+    func requestRecordPermission(_ response: @escaping (Bool) -> Void) {
+        audioSession.requestRecordPermission(response)
+    }
+}
+
+private extension MicrophoneManager {
     @objc func getMeasurement() {
+        if !recorder.isRecording {
+            recorder.record()
+        }
         recorder.updateMeters()
-        
         let level = recorder.averagePower(forChannel: 0)
+        try! createMeasurement(value: level)
+    }
+    
+    @objc func handleInterruption(notification: Notification) {
+        let typeValue = notification.userInfo![AVAudioSessionInterruptionTypeKey] as! UInt
+        let type = AVAudioSession.InterruptionType(rawValue: typeValue)!
+        
+        switch type {
+        case .ended:
+            levelTimer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(getMeasurement), userInfo: nil, repeats: true)
+        case .began:
+            fallthrough
+        @unknown default:
+            levelTimer.invalidate()
+            session!.status = .DISCONNETCED
+        }
+    }
+    
+    func createMeasurement(value: Float) throws {
         let startingLocation = obtainCurrentLocation()
         
         let measurement = Measurement(context: self.context)
         
         measurement.latitude = startingLocation.latitude
         measurement.longitude = startingLocation.longitude
-        measurement.value = Double(level)
+        measurement.value = Double(value)
         measurement.time = Date()
         
-        session?.endTime = measurement.time
-        session?.status = .RECORDING
+        session!.endTime = measurement.time
+        session!.status = .RECORDING
         
-        measurementStream?.addToMeasurements(measurement)
+        measurementStream!.addToMeasurements(measurement)
         
-        do {
-            try context.save()
-        } catch {
-            print(error)
-        }
+        try context.save()
     }
     
-    func stopRecording() {
-        levelTimer.invalidate()
-        isRecording = false
+    func createDBStream(for session: Session) {
+        let stream = MeasurementStream(context: self.context)
+        stream.sensorName = "Phone Microphone-dB"
+        stream.sensorPackageName = "Builtin"
+        stream.measurementType = "Sound Level"
+        stream.measurementShortType = "db"
+        stream.unitName = "decibels"
+        stream.unitSymbol = "dB"
+        stream.thresholdVeryLow = 20
+        stream.thresholdLow = 60
+        stream.thresholdMedium = 70
+        stream.thresholdHigh = 80
+        stream.thresholdVeryHigh = 100
+        stream.gotDeleted = false
+        
+        measurementStream = stream
+        
+        session.addToMeasurementStreams(measurementStream!)
     }
     
-    private
-    
-    func createDBStream() {
-        if let session = session {
-            let stream = MeasurementStream(context: self.context)
-            stream.sensorName = "Phone Microphone-dB"
-            stream.sensorPackageName = "Builtin"
-            stream.measurementType = "Sound Level"
-            stream.measurementShortType = "db"
-            stream.unitName = "decibels"
-            stream.unitSymbol = "dB"
-            stream.thresholdVeryLow = 20
-            stream.thresholdLow = 60
-            stream.thresholdMedium = 70
-            stream.thresholdHigh = 80
-            stream.thresholdVeryHigh = 100
-            stream.gotDeleted = false
-            
-            measurementStream = stream
-            
-            session.addToMeasurementStreams(measurementStream!)
-        }
-    }
-
     func obtainCurrentLocation() -> CLLocationCoordinate2D {
-        return locationProvider.currentLocation?.coordinate ?? CLLocationCoordinate2D(latitude: 200.0, longitude: 200.0)
+        locationProvider.currentLocation?.coordinate ?? CLLocationCoordinate2D(latitude: 200.0, longitude: 200.0)
     }
     
+    func addInterruptionsObserver() {
+        notificationCenter.addObserver(self,
+                                       selector: #selector(handleInterruption),
+                                       name: AVAudioSession.interruptionNotification,
+                                       object: audioSession)
+    }
+    
+    func removeInterruptionsObserver() {
+        notificationCenter.removeObserver(self, name: AVAudioSession.interruptionNotification, object: audioSession)
+    }
+    
+    enum MicrophoneSessionError: Error {
+        case sessionNotSet
+        case permissionNotGranted
+    }
 }

--- a/AirCasting/Models/SessionContext.swift
+++ b/AirCasting/Models/SessionContext.swift
@@ -129,7 +129,11 @@ class CreateSessionContext: ObservableObject {
         session.longitude = startingLocation.longitude
         session.latitude = startingLocation.latitude
         
-        microphoneManager.startRecording(session: session)
+        do {
+            try microphoneManager.startRecording(session: session)
+        } catch {
+            assertionFailure("Can't start recording microphone session: \(error)")
+        }
     }
     
 }

--- a/AirCasting/SessionViews/SessionHeaderView.swift
+++ b/AirCasting/SessionViews/SessionHeaderView.swift
@@ -23,8 +23,9 @@ struct SessionHeaderView: View {
                 HStack {
                     measurementsMic
                     Spacer()
-                    if microphoneManager.isRecording {
-                        stopRecordingButton //This is a temporary solution
+                    //This is a temporary solution for stopping mic session recording until we implement proper session edition menu
+                    if microphoneManager.isRecording && session.status == .RECORDING {
+                        stopRecordingButton
                     }
                 }
             } else {
@@ -33,7 +34,6 @@ struct SessionHeaderView: View {
         }
         .font(Font.moderate(size: 13, weight: .regular))
         .foregroundColor(.aircastingGray)
-        
     }
     
     var dateAndTime: some View {
@@ -113,7 +113,7 @@ struct SessionHeaderView: View {
     
     var stopRecordingButton: some View {
         Button(action: {
-            microphoneManager.stopRecording()
+            try! microphoneManager.stopRecording()
         }, label: {
             Text("Stop recording")
                 .foregroundColor(.blue)

--- a/AirCasting/Utils/SettingsManager.swift
+++ b/AirCasting/Utils/SettingsManager.swift
@@ -1,0 +1,18 @@
+// Created by Lunar on 22/04/2021.
+//
+
+import Foundation
+import SwiftUI
+
+class SettingsManager {
+    static func goToAuthSettings() {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else {
+            Log.error("Couldn't get settings url")
+            return
+        }
+        let app = UIApplication.shared
+        if app.canOpenURL(url) {
+            app.open(url, options: [:], completionHandler: nil)
+        }
+    }
+}


### PR DESCRIPTION
### Summary
* Change flow for checking users permission for microphone. User gets ask to give permission to access microphone when they choose microphone in the `ChooseSessionTypeView`. If they give permission then we go further with the views for creating microphone session. When they don't give permission then they get sent to setting app every time they try to choose microphone
* Add functionality for resuming recording after audio session gets interrupted eg. by incoming phonecall or by another app