### PR TITLE
Quick fixes

### DIFF
--- a/AirCasting/APICommunicator/AuthorizationAPI.swift
+++ b/AirCasting/APICommunicator/AuthorizationAPI.swift
@@ -52,7 +52,7 @@ enum AuthorizationError: Error, LocalizedError, Identifiable {
         case .noConnection:
             return NSLocalizedString("Please, make sure your device is connected to the internet.", comment: "connection failure login message failure")
         case .usernameTaken, .emailTaken, .invalidCredentials:
-            return NSLocalizedString("The username or password is incorrect. Please, try again.", comment: "connection failure login message failure")
+            return NSLocalizedString("Email or profile name is already in use. Please try again.", comment: "connection failure login message failure")
         }
     }
     

--- a/AirCasting/AuthViews/CreateAccountView.swift
+++ b/AirCasting/AuthViews/CreateAccountView.swift
@@ -109,6 +109,8 @@ private extension CreateAccountView {
     var createAccountButton: some View {
         Button("Continue") {
             checkIfUserInputIsCorrect()
+            // Hiding keyboard prevents from double displaying alert
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
             
             if isPasswordCorrect && isEmailCorrect && !isUsernameBlank {
                 #warning("Show progress and lock ui to prevent multiple api calls")
@@ -120,7 +122,7 @@ private extension CreateAccountView {
                     DispatchQueue.main.async {
                         switch result {
                         case .failure(let error):
-                            presentedError = error
+                                presentedError = error
                             Log.warning("Failed to create account \(error)")
                         case .success(let output):
                             Log.info("Successfully created account")

--- a/AirCasting/AuthViews/CreateAccountView.swift
+++ b/AirCasting/AuthViews/CreateAccountView.swift
@@ -167,7 +167,7 @@ private extension CreateAccountView {
         switch error {
         case .emailTaken, .invalidCredentials, .usernameTaken:
             return Alert(title: Text(title),
-                         message: Text("The profile name or password is incorrect. Please, try again. "),
+                         message: Text("Email or profile name is already in use. Please try again."),
                          dismissButton: .default(Text("Ok")))
 
         case .noConnection:

--- a/AirCasting/AuthViews/SignInView.swift
+++ b/AirCasting/AuthViews/SignInView.swift
@@ -141,12 +141,12 @@ private extension SignInView {
         switch error {
         case .emailTaken, .invalidCredentials, .usernameTaken:
             return Alert(title: Text(title),
-                         message: Text("The profile name or password is incorrect. Please, try again. "),
+                         message: Text("The profile name or password is incorrect. Please try again. "),
                          dismissButton: .default(Text("Ok")))
 
         case .noConnection:
             return Alert(title: Text("No Internet Connection"),
-                         message: Text("Please, make sure your device is connected to the internet."),
+                         message: Text("Please make sure your device is connected to the internet."),
                          dismissButton: .default(Text("Ok")))
         case .other, .timeout:
             return Alert(title: Text(title),


### PR DESCRIPTION
Super small fixes: 
1. Changed alerts message when there's an incorrect mail/profile name while creating an account.  
2. Fixed bug - after clicking "continue" in create account view, if the input was wrong the alert was appeared, disappeared by itself, and appeared again. I fixed it by dismissing the keyboard just after clicking the Continue button. Not sure if this "hack" is a solution to this problem but I didn't find anything better. 