### PR TITLE
Graph part 2.

### DIFF
--- a/AirCasting.xcodeproj/project.pbxproj
+++ b/AirCasting.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		AC7EB3B125A7152000A7F2AF /* Muli-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AC7EB39B25A7152000A7F2AF /* Muli-Regular.ttf */; };
 		AC7EB3B225A7152000A7F2AF /* Muli-LightItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AC7EB39C25A7152000A7F2AF /* Muli-LightItalic.ttf */; };
 		AC7EB3B325A7152000A7F2AF /* Moderat-Trial-Black.otf in Resources */ = {isa = PBXBuildFile; fileRef = AC7EB39D25A7152000A7F2AF /* Moderat-Trial-Black.otf */; };
+		AC8431D0265E6143004DC890 /* RemoveOldMeasurementsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8431CF265E6143004DC890 /* RemoveOldMeasurementsService.swift */; };
 		AC86EE6B25D03DC00083F8C0 /* SelectDeviceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC86EE6A25D03DC00083F8C0 /* SelectDeviceView.swift */; };
 		AC8CFF3625E502DD00FB2918 /* CreateAccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8CFF3525E502DD00FB2918 /* CreateAccountView.swift */; };
 		AC8CFF4125E5095600FB2918 /* Textfield.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8CFF4025E5095600FB2918 /* Textfield.swift */; };
@@ -234,6 +235,7 @@
 		AC7EB39B25A7152000A7F2AF /* Muli-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Muli-Regular.ttf"; sourceTree = "<group>"; };
 		AC7EB39C25A7152000A7F2AF /* Muli-LightItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Muli-LightItalic.ttf"; sourceTree = "<group>"; };
 		AC7EB39D25A7152000A7F2AF /* Moderat-Trial-Black.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Moderat-Trial-Black.otf"; sourceTree = "<group>"; };
+		AC8431CF265E6143004DC890 /* RemoveOldMeasurementsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveOldMeasurementsService.swift; sourceTree = "<group>"; };
 		AC86EE6A25D03DC00083F8C0 /* SelectDeviceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectDeviceView.swift; sourceTree = "<group>"; };
 		AC8CFF3525E502DD00FB2918 /* CreateAccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateAccountView.swift; sourceTree = "<group>"; };
 		AC8CFF4025E5095600FB2918 /* Textfield.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Textfield.swift; sourceTree = "<group>"; };
@@ -639,6 +641,7 @@
 			children = (
 				ACF7C05E260CC9FF007C24AE /* DownloadMeasurmentsService.swift */,
 				AC524A8D2615C8270061AD45 /* UpdateSessionParams.swift */,
+				AC8431CF265E6143004DC890 /* RemoveOldMeasurementsService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -913,6 +916,7 @@
 				AC3203CB25CA991C00A68520 /* TurnOnBluetoothView.swift in Sources */,
 				4FF60BEA265500C4001618BE /* BluetoothManager.swift in Sources */,
 				AC32043625CD534700A68520 /* ChooseSessionTypeView.swift in Sources */,
+				AC8431D0265E6143004DC890 /* RemoveOldMeasurementsService.swift in Sources */,
 				ACF7C05F260CC9FF007C24AE /* DownloadMeasurmentsService.swift in Sources */,
 				AC9F526E2652A360003CF61F /* AirSectionPickerView.swift in Sources */,
 				AC7EB37825A6FB3A00A7F2AF /* MainTabBarView.swift in Sources */,

--- a/AirCasting/Graph/Graph.swift
+++ b/AirCasting/Graph/Graph.swift
@@ -12,10 +12,12 @@ class UI_PollutionGraph: UIView {
     
     let lineChartView = LineChartView()
     var renderer: MultiColorGridRenderer?
+    var didMoveOrScaleGraph = false
     
     init() {
         super.init(frame: .zero)
         self.addSubview(lineChartView)
+        lineChartView.delegate = self
         try? setupGraph()
     }
     
@@ -48,7 +50,7 @@ class UI_PollutionGraph: UIView {
         lineChartView.xAxis.drawLabelsEnabled = true
         lineChartView.xAxis.labelCount = 2
         lineChartView.extraBottomOffset = 25
-        
+                
         lineChartView.xAxisRenderer = TimeAxisRenderer(viewPortHandler: lineChartView.viewPortHandler,
                                                        xAxis: lineChartView.xAxis,
                                                        transformer: lineChartView.getTransformer(forAxis: .left))
@@ -90,10 +92,34 @@ class UI_PollutionGraph: UIView {
         dataSet.setColor(UIColor(.white))
         dataSet.mode = .linear
         dataSet.lineWidth = 4
+        
+        if !didMoveOrScaleGraph {
+            zoomoutToThirtyMinutes(dataSet: dataSet)
+        }
+    }
+    
+    func zoomoutToThirtyMinutes(dataSet: LineChartDataSet) {
+        let thirtyMinutesMeasurementCount = 60 * 30
+        lineChartView.setVisibleXRangeMaximum(Double(thirtyMinutesMeasurementCount))
+        lineChartView.moveViewToX(dataSet.xMax)
+        //enable zoom out
+        lineChartView.setVisibleXRangeMaximum(dataSet.xMax)
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension UI_PollutionGraph: ChartViewDelegate {
+    
+    // Callbacks when the chart is scaled / zoomed via pinch zoom gesture.
+    @objc func chartScaled(_ chartView: ChartViewBase, scaleX: CGFloat, scaleY: CGFloat) {
+        didMoveOrScaleGraph = true
+    }
+    // Callbacks when the chart is moved / translated via drag gesture.
+    @objc func chartTranslated(_ chartView: ChartViewBase, dX: CGFloat, dY: CGFloat) {
+        didMoveOrScaleGraph = true
     }
 }
 

--- a/AirCasting/Graph/Graph.swift
+++ b/AirCasting/Graph/Graph.swift
@@ -69,7 +69,6 @@ class UI_PollutionGraph: UIView {
         guard let renderer = renderer else {
             throw GraphError.rendererError
         }
-        
         renderer.thresholds = thresholdValues
         
         lineChartView.leftAxis.axisMinimum = Double(thresholdValues.first ?? 0)
@@ -79,7 +78,7 @@ class UI_PollutionGraph: UIView {
         lineChartView.setNeedsDisplay()
     }
     
-    func updateWithEntries(entries: [ChartDataEntry]) {
+    func updateWithEntries(entries: [ChartDataEntry], isSessionMobile: Bool) {
         let dataSet = LineChartDataSet(entries: entries)
         let data = LineChartData(dataSet: dataSet)
         lineChartView.data = data
@@ -93,7 +92,7 @@ class UI_PollutionGraph: UIView {
         dataSet.mode = .linear
         dataSet.lineWidth = 4
         
-        if !didMoveOrScaleGraph {
+        if !didMoveOrScaleGraph && isSessionMobile {
             zoomoutToThirtyMinutes(dataSet: dataSet)
         }
     }
@@ -199,6 +198,7 @@ struct Graph: UIViewRepresentable {
     
     @ObservedObject var stream: MeasurementStreamEntity
     @ObservedObject var thresholds: SensorThreshold
+    var isSessionMobile: Bool
     
     func makeUIView(context: Context) -> UI_PollutionGraph {
         UI_PollutionGraph()
@@ -213,15 +213,14 @@ struct Graph: UIViewRepresentable {
             let chartDataEntry = ChartDataEntry(x: timeInterval, y: measurement.value)
             return chartDataEntry
         }) ?? []
-        
-        uiView.updateWithEntries(entries: entries)
+        uiView.updateWithEntries(entries: entries, isSessionMobile: isSessionMobile)
     }
 }
 
 #if DEBUG
 struct PollutionGraph_Previews: PreviewProvider {
     static var previews: some View {
-        Graph(stream: .mock, thresholds: .mock)
+        Graph(stream: .mock, thresholds: .mock, isSessionMobile: true)
     }
 }
 #endif

--- a/AirCasting/Graph/GraphView.swift
+++ b/AirCasting/Graph/GraphView.swift
@@ -21,7 +21,9 @@ struct GraphView: View {
             
             ZStack(alignment: .topLeading) {
                 #warning("Replace dbStream with currently selected")
-                Graph(stream: session.dbStream!, thresholds: thresholds[0])
+                Graph(stream: session.dbStream!,
+                      thresholds: thresholds[0],
+                      isSessionMobile: session.type == .mobile)
                 StatisticsContainerView()
             }
             

--- a/AirCasting/Graph/GraphView.swift
+++ b/AirCasting/Graph/GraphView.swift
@@ -23,7 +23,7 @@ struct GraphView: View {
                 #warning("Replace dbStream with currently selected")
                 Graph(stream: session.dbStream!,
                       thresholds: thresholds[0],
-                      isSessionMobile: session.type == .mobile)
+                      isAutozoomEnabled: session.type == .mobile)
                 StatisticsContainerView()
             }
             

--- a/AirCasting/Services/DownloadMeasurmentsService.swift
+++ b/AirCasting/Services/DownloadMeasurmentsService.swift
@@ -67,6 +67,10 @@ final class DownloadMeasurementsService: MeasurementUpdatingService {
                     } catch {
                         assertionFailure("Failed to save context \(error)")
                     }
+                    PersistenceController.shared.performBackgroundTask { bgContext in
+                        RemoveOldMeasurementsService().removeOldestMeasurements(context: bgContext,
+                                                                                uuid: uuid)
+                    }
                 case .failure(let error):
                     Log.warning("Failed to fetch measurements for uuid '\(uuid)' \(error)")
                 }

--- a/AirCasting/Services/RemoveOldMeasurementsService.swift
+++ b/AirCasting/Services/RemoveOldMeasurementsService.swift
@@ -8,42 +8,27 @@ import CoreData
 final class RemoveOldMeasurementsService {
     
     enum Error: Swift.Error {
-        case sessionFetchFailed
         case removingMeasurementsSurplusFailed
+        case noStreamInSession
+    }
+    
+    private static let twentyFourHoursMeasurementCount = 24 * 60
+    
+    /// In fixed sessions we need to remove measurements older than 24h, but we treat 24 not like a date, but as a sum of measurements.
+    /// We know that we have 60 measurements per hour, so we take 1440 last measurements for each stream, and we remove older than the first of them.
+    func removeOldestMeasurements(in context: NSManagedObjectContext, uuid: SessionUUID) throws {
+        let session = try context.existingSession(uuid: uuid)
+        try removeMeasurementsSurplus(context: context, session: session)
+    }
+    
+    private func removeMeasurementsSurplus(context: NSManagedObjectContext, session: SessionEntity) throws {
+        guard let streams = session.measurementStreams?.array as? [MeasurementStreamEntity] else { throw Error.noStreamInSession }
         
-    }
-    private let twentyFourHoursMeasurementCount = 24 * 60
-    
-    func removeOldestMeasurements(context: NSManagedObjectContext, uuid: SessionUUID) {
-        /// In fixed sessions we need to remove measurements older than 24h, but we treat 24 not like a date, but as a sum of measurements.
-        /// We know that we have 60 measurements per hour, so we take 1440 last measurements for each stream, and we remove older than the first of them.
-        do {
-            let session = try fetchSession(context: context, uuid: uuid)
-            removeMeasurementsSurplus(context: context, session: session)
-        } catch {
-            Log.error("Error: \(Error.removingMeasurementsSurplusFailed)")
-        }
-    }
-    
-    private func fetchSession(context: NSManagedObjectContext, uuid: SessionUUID) throws -> SessionEntity {
-        let request: NSFetchRequest<SessionEntity> = SessionEntity.fetchRequest()
-        request.predicate = request.typePredicate(.fixed)
-        request.predicate = NSPredicate(format: "uuid == %@", uuid.rawValue)
-        let fetchedSessions = try context.fetch(request)
-        
-        guard let session = fetchedSessions.first else {
-            throw Error.sessionFetchFailed
-        }
-        return session
-    }
-    
-    private func removeMeasurementsSurplus(context: NSManagedObjectContext, session: SessionEntity) {
-        for stream in session.measurementStreams! {
-            let stream: MeasurementStreamEntity = stream as! MeasurementStreamEntity
-            let measurementsCount = stream.measurements!.count
+        for stream in streams {
+            guard let measurementsCount = stream.measurements?.count else { continue }
             
-            if measurementsCount > twentyFourHoursMeasurementCount {
-                let surplus = stream.allMeasurements?.prefix(measurementsCount - twentyFourHoursMeasurementCount) ?? []
+            if measurementsCount > RemoveOldMeasurementsService.twentyFourHoursMeasurementCount {
+                let surplus = stream.allMeasurements?.prefix(measurementsCount - RemoveOldMeasurementsService.twentyFourHoursMeasurementCount) ?? []
                 for measurement in surplus {
                     context.delete(measurement)
                 }

--- a/AirCasting/Services/RemoveOldMeasurementsService.swift
+++ b/AirCasting/Services/RemoveOldMeasurementsService.swift
@@ -1,0 +1,53 @@
+// Created by Lunar on 26/05/2021.
+//
+
+import Foundation
+import CoreData
+
+
+final class RemoveOldMeasurementsService {
+    
+    enum Error: Swift.Error {
+        case sessionFetchFailed
+        case removingMeasurementsSurplusFailed
+        
+    }
+    private let twentyFourHoursMeasurementCount = 24 * 60
+    
+    func removeOldestMeasurements(context: NSManagedObjectContext, uuid: SessionUUID) {
+        /// In fixed sessions we need to remove measurements older than 24h, but we treat 24 not like a date, but as a sum of measurements.
+        /// We know that we have 60 measurements per hour, so we take 1440 last measurements for each stream, and we remove older than the first of them.
+        do {
+            let session = try fetchSession(context: context, uuid: uuid)
+            removeMeasurementsSurplus(context: context, session: session)
+        } catch {
+            Log.error("Error: \(Error.removingMeasurementsSurplusFailed)")
+        }
+    }
+    
+    private func fetchSession(context: NSManagedObjectContext, uuid: SessionUUID) throws -> SessionEntity {
+        let request: NSFetchRequest<SessionEntity> = SessionEntity.fetchRequest()
+        request.predicate = request.typePredicate(.fixed)
+        request.predicate = NSPredicate(format: "uuid == %@", uuid.rawValue)
+        let fetchedSessions = try context.fetch(request)
+        
+        guard let session = fetchedSessions.first else {
+            throw Error.sessionFetchFailed
+        }
+        return session
+    }
+    
+    private func removeMeasurementsSurplus(context: NSManagedObjectContext, session: SessionEntity) {
+        for stream in session.measurementStreams! {
+            let stream: MeasurementStreamEntity = stream as! MeasurementStreamEntity
+            let measurementsCount = stream.measurements!.count
+            
+            if measurementsCount > twentyFourHoursMeasurementCount {
+                let surplus = stream.allMeasurements?.prefix(measurementsCount - twentyFourHoursMeasurementCount) ?? []
+                for measurement in surplus {
+                    context.delete(measurement)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
@anna1901 I merged graph part 1 but you asked there why `extension MeasurementStreamEntity {` isn't in a separate file. The answer is: I wanted to have mocked session and mocked stream in one file. If you think I should move it to a separate file, please write a comment in this PR :-) 

**Summary**
- I limit the number of measurements for the fixed session to 1440 (24h of measurements). I create a background context to fetch session, check if any of the session streams has more than 1440 measurements. If yes, I remove the surplus from the beginning of the array of measurements. 
- I add a zoom mobile session graph to show the last 30 minutes by setting 1800 as a maximum visible range for the X axis. 
