### PR TITLE
Add ScrollViewReader

### DIFF
--- a/AirCasting/Dashboard/AirSectionPickerView.swift
+++ b/AirCasting/Dashboard/AirSectionPickerView.swift
@@ -8,15 +8,23 @@ struct AirSectionPickerView: View {
     @Binding var selection: SelectedSection
     
     var body: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack {
-                ForEach(SelectedSection.allCases, id: \.self) { section in
-                    Button(section.localizedString) {
-                        withAnimation(.easeInOut(duration: 0.1)) {
-                            selection = section
+        ScrollViewReader { scrollReader in
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack {
+                    ForEach(SelectedSection.allCases, id: \.self) { section in
+                        Button(section.localizedString) {
+                            withAnimation(.easeInOut(duration: 0.1)) {
+                                if section == .mobileDormant {
+                                    scrollReader.scrollTo(SelectedSection.fixed)
+                                } else if section == .mobileActive {
+                                    scrollReader.scrollTo(SelectedSection.following)
+                                }
+                                selection = section
+                            }
                         }
+                        .buttonStyle(PickerButtonStyle(isSelected: section == selection))
+                        .id(section)
                     }
-                    .buttonStyle(PickerButtonStyle(isSelected: section == selection))
                 }
             }
         }


### PR DESCRIPTION
The bug was: https://trello.com/c/P4N33Xha/75-tabs-for-following-mobile-active-dormant-fixed-in-dashboard

We have a custom section picker and I created a workaround for this, hope it'll work ok. 
I added a ScrollViewReader that scrolls section picker to show the "fixed" tab when the user chooses "dormant", and to show the "following" tab when the user chooses the "active" :) 
