### PR TITLE
Naive dBFS -> dB convertion mechanism added

### DIFF
--- a/AirCasting/MicrophoneSession/MicrophoneManager.swift
+++ b/AirCasting/MicrophoneSession/MicrophoneManager.swift
@@ -98,10 +98,11 @@ extension MicrophoneManager: AVAudioRecorderDelegate {
 private extension MicrophoneManager {
     func sampleMeasurement() throws {
         recorder.updateMeters()
-        let value = Double(recorder.averagePower(forChannel: 0))
+        let power = recorder.averagePower(forChannel: 0)
+        let decibels = Double(power + 90.0)
         let location = obtainCurrentLocation()
-        Log.debug("New mic measurement \(value) at \(String(describing: location))")
-        try measurementStreamStorage.addMeasurementValue(value, at: location, toStreamWithID: measurementStreamLocalID!)
+        Log.debug("New mic measurement \(decibels) at \(String(describing: location))")
+        try measurementStreamStorage.addMeasurementValue(decibels, at: location, toStreamWithID: measurementStreamLocalID!)
     }
 
     @objc func timerTick() {


### PR DESCRIPTION
This is so bad, but converting dbfs values to db is not possible without at least some calibration (experimented with many other "tricks", but it always boil down to this, so no point in doing any advanced algo here if we don't have this much required anchor)