### PR TITLE
fixed session indoor - map button removed

### DIFF
--- a/AirCasting/SessionViews/SessionCartView.swift
+++ b/AirCasting/SessionViews/SessionCartView.swift
@@ -119,7 +119,9 @@ private extension SessionCartView {
     
     func displayButtons(thresholds: [SensorThreshold]) -> some View {
         HStack(spacing: 20) {
-            mapButton(thresholds: thresholds)
+            if session.isIndoor && session.type == .fixed {
+                mapButton(thresholds: thresholds)
+            }
             graphButton(thresholds: thresholds)
         }
         .buttonStyle(GrayButtonStyle())

--- a/AirCasting/SessionViews/SessionCartView.swift
+++ b/AirCasting/SessionViews/SessionCartView.swift
@@ -119,7 +119,7 @@ private extension SessionCartView {
     
     func displayButtons(thresholds: [SensorThreshold]) -> some View {
         HStack(spacing: 20) {
-            if session.isIndoor && session.type == .fixed {
+            if !session.isIndoor && session.type != .fixed {
                 mapButton(thresholds: thresholds)
             }
             graphButton(thresholds: thresholds)


### PR DESCRIPTION
What was done:

Map button was changed to if {} and now only shown when not indoor && fixed

https://trello.com/c/Ky1FINec/154-indoor-sessions