### PR TITLE
Fixed measurements are fetched by lastSync date

### DIFF
--- a/AirCasting/CoreData/PersistenceController+Database.swift
+++ b/AirCasting/CoreData/PersistenceController+Database.swift
@@ -48,6 +48,7 @@ extension PersistenceController: SessionInsertable {
                 sessionEntity.status = $0.status
                 $0.measurementStreams?.forEach {
                     let streamEntity = MeasurementStreamEntity(context: context)
+                    streamEntity.id = $0.id
                     streamEntity.measurementShortType = $0.measurementShortType
                     streamEntity.measurementType = $0.measurementType
                     streamEntity.sensorName = $0.sensorName

--- a/AirCasting/Services/DownloadMeasurmentsService.swift
+++ b/AirCasting/Services/DownloadMeasurmentsService.swift
@@ -65,7 +65,6 @@ final class DownloadMeasurementsService: MeasurementUpdatingService {
             DispatchQueue.main.async {
                 switch result {
                 case .success(let response):
-                    print("From sync date: \(syncDate)")
                     let context = persistenceController.editContext()
                     do {
                         let session: SessionEntity = try context.newOrExisting(uuid: response.uuid)
@@ -101,10 +100,6 @@ final class DownloadMeasurementsService: MeasurementUpdatingService {
         guard let lastMeasurementTime = lastMeasurementTime else { return last24hours }
         let lastMeasurementSeconds = lastMeasurementTime.timeIntervalSince1970
         
-        if (sessionEndTimeSeconds - lastMeasurementSeconds) <  measurementTimeframe {
-            return lastMeasurementTime
-        } else {
-            return last24hours
-        }
+        return ((sessionEndTimeSeconds - lastMeasurementSeconds) < measurementTimeframe) ? lastMeasurementTime : last24hours
     }
 }


### PR DESCRIPTION
What was done is well explained here: https://trello.com/c/th6aThho/71-replace-mocked-lastsync-date-in-updateforsession-funcion-in-downloadmeasurementsservice

