### PR TITLE
Fix bluetooth bug

### DIFF
--- a/AirCasting/ABConnector/BluetoothManager.swift
+++ b/AirCasting/ABConnector/BluetoothManager.swift
@@ -58,6 +58,11 @@ class BluetoothManager: NSObject, ObservableObject {
     
     init(mobilePeripheralSessionManager: MobilePeripheralSessionManager) {
         self.mobilePeripheralSessionManager = mobilePeripheralSessionManager
+        super.init()
+        if CBCentralManager.authorization == .allowedAlways {
+            // To avoid the .unknown state of centralManager when bluetooth is poweredOn
+            let _ = centralManager
+        }
     }
 }
 

--- a/AirCasting/CreateSessionViews/Handlers/BluetoothHandler.swift
+++ b/AirCasting/CreateSessionViews/Handlers/BluetoothHandler.swift
@@ -21,7 +21,7 @@ class DefaultBluetoothHandler: BluetoothHandler {
     }
     
     func isBluetoothDenied() -> Bool {
-        CBCentralManager.authorization != .allowedAlways ? true : false
+        CBCentralManager.authorization == .denied || CBCentralManager.authorization == .notDetermined || bluetoothManager.centralManager.state != .poweredOn  ? true : false
     }
 }
 

--- a/AirCasting/CreateSessionViews/Handlers/BluetoothHandler.swift
+++ b/AirCasting/CreateSessionViews/Handlers/BluetoothHandler.swift
@@ -21,7 +21,7 @@ class DefaultBluetoothHandler: BluetoothHandler {
     }
     
     func isBluetoothDenied() -> Bool {
-        CBCentralManager.authorization == .denied || CBCentralManager.authorization == .notDetermined || bluetoothManager.centralManager.state != .poweredOn  ? true : false
+        CBCentralManager.authorization != .allowedAlways || bluetoothManager.centralManager.state != .poweredOn  ? true : false
     }
 }
 

--- a/AirCasting/CreateSessionViews/SelectDeviceView.swift
+++ b/AirCasting/CreateSessionViews/SelectDeviceView.swift
@@ -113,10 +113,10 @@ struct SelectDeviceView: View {
     var chooseButton: some View {
         Button(action: {
             if selected == 1 {
-                if CBCentralManager.authorization != .allowedAlways {
-                    isTurnOnBluetoothLinkActive = true
-                } else {
+                if CBCentralManager.authorization != .denied && bluetoothManager.centralManagerState == .poweredOn {
                     isPowerABLinkActive = true
+                } else {
+                    isTurnOnBluetoothLinkActive = true
                 }
             } else if selected == 2 {
                 if microphoneManager.recordPermissionGranted() {

--- a/AirCasting/CreateSessionViews/TurnOnBluetoothView.swift
+++ b/AirCasting/CreateSessionViews/TurnOnBluetoothView.swift
@@ -65,10 +65,12 @@ struct TurnOnBluetoothView: View {
     var continueButton: some View {
         Button(action: {
             if CBCentralManager.authorization == .denied {
+                settingsRedirection.goToAppsBluetoothAuthSettings()
+            } else if bluetoothManager.centralManager.state != .poweredOn {
                 settingsRedirection.goToBluetoothAuthSettings()
-            } else if CBCentralManager.authorization != .denied {
-                    isPowerABLinkActive = true
-                }
+            } else {
+                isPowerABLinkActive = true
+            }
         }, label: {
             Text(Strings.TurnOnBluetoothView.continueButton)
         })

--- a/AirCasting/RootAppView.swift
+++ b/AirCasting/RootAppView.swift
@@ -8,54 +8,69 @@
 import SwiftUI
 import CoreLocation
 
-class Dependancies {
-    let networkChecker = NetworkChecker(connectionAvailable: false)
-    let bluetoothManager = BluetoothManager(mobilePeripheralSessionManager: MobilePeripheralSessionManager(measurementStreamStorage: CoreDataMeasurementStreamStorage(persistenceController: PersistenceController.shared)))
-    let urlProvider = UserDefaultsBaseURLProvider()
-    lazy var airBeamConnectionController = DefaultAirBeamConnectionController(connectingAirBeamServices: ConnectingAirBeamServicesBluetooth(bluetoothConnector: bluetoothManager))
-}
-
 struct RootAppView: View {
-    var dependancies = Dependancies()
-    private let measurementStreamStorage: MeasurementStreamStorage = CoreDataMeasurementStreamStorage(persistenceController: PersistenceController.shared)
-    @ObservedObject var lifeTimeEventsProvider = LifeTimeEventsProvider()
-    @ObservedObject var userSettings = UserSettings()
-    @ObservedObject var locationTracker = LocationTracker(locationManager: CLLocationManager())
-    @ObservedObject var userRedirectionSettings = DefaultSettingsRedirection()
-    let urlProvider = UserDefaultsBaseURLProvider()
+    
+    @State private var airBeamConnectionController: DefaultAirBeamConnectionController?
+    @StateObject private var bluetoothManager = BluetoothManager(mobilePeripheralSessionManager: MobilePeripheralSessionManager(measurementStreamStorage: CoreDataMeasurementStreamStorage(persistenceController: PersistenceController.shared)))
+    @StateObject private var lifeTimeEventsProvider = LifeTimeEventsProvider()
+    @StateObject private var userSettings = UserSettings()
+    @StateObject private var locationTracker = LocationTracker(locationManager: CLLocationManager())
+    @StateObject private var userRedirectionSettings = DefaultSettingsRedirection()
+    @EnvironmentObject var userAuthenticationSession: UserAuthenticationSession
     var sessionSynchronizer: SessionSynchronizer
     let persistenceController: PersistenceController
-    @EnvironmentObject var userAuthenticationSession: UserAuthenticationSession
+    let urlProvider = UserDefaultsBaseURLProvider()
+    let networkChecker = NetworkChecker(connectionAvailable: false)
+    
     var body: some View {
-        if userAuthenticationSession.isLoggedIn {
-            mainAppView
-        } else if !userAuthenticationSession.isLoggedIn && lifeTimeEventsProvider.hasEverPassedOnBoarding {
-            NavigationView {
-                CreateAccountView(completion: { self.lifeTimeEventsProvider.hasEverLoggedIn = true }, userSession: userAuthenticationSession, baseURL: dependancies.urlProvider).environmentObject(lifeTimeEventsProvider)
+        ZStack {
+            if userAuthenticationSession.isLoggedIn,
+               let airBeamConnectionController = airBeamConnectionController {
+                MainAppView(airBeamConnectionController: airBeamConnectionController,
+                            sessionSynchronizer: sessionSynchronizer)
+            } else if !userAuthenticationSession.isLoggedIn && lifeTimeEventsProvider.hasEverPassedOnBoarding {
+                NavigationView {
+                    CreateAccountView(completion: { self.lifeTimeEventsProvider.hasEverLoggedIn = true }, userSession: userAuthenticationSession, baseURL: urlProvider).environmentObject(lifeTimeEventsProvider)
+                }
+            } else {
+                GetStarted(completion: {
+                    self.lifeTimeEventsProvider.hasEverPassedOnBoarding = true
+                })
             }
-        } else {
-            GetStarted(completion: {
-                self.lifeTimeEventsProvider.hasEverPassedOnBoarding = true
-            })
+        }
+        .environmentObject(bluetoothManager)
+        .environmentObject(userAuthenticationSession)
+        .environmentObject(persistenceController)
+        .environmentObject(networkChecker)
+        .environmentObject(lifeTimeEventsProvider)
+        .environmentObject(userSettings)
+        .environmentObject(locationTracker)
+        .environmentObject(userRedirectionSettings)
+        .environmentObject(urlProvider)
+        .environment(\.managedObjectContext, persistenceController.viewContext)
+        .onAppear {
+            airBeamConnectionController =  DefaultAirBeamConnectionController(connectingAirBeamServices: ConnectingAirBeamServicesBluetooth(bluetoothConnector: bluetoothManager))
         }
     }
+    
+}
 
-    var mainAppView: some View {
-            MainTabBarView(measurementUpdatingService: DownloadMeasurementsService(
-                            authorisationService: userAuthenticationSession,
-                            persistenceController: persistenceController,
-                            baseUrl: dependancies.urlProvider), urlProvider: dependancies.urlProvider, measurementStreamStorage: measurementStreamStorage, sessionSynchronizer: sessionSynchronizer, sessionContext: CreateSessionContext())
-                .environmentObject(dependancies.bluetoothManager)
-                .environmentObject(userAuthenticationSession)
-                .environmentObject(persistenceController)
-                .environmentObject(dependancies.networkChecker)
-                .environmentObject(lifeTimeEventsProvider)
-                .environmentObject(userSettings)
-                .environmentObject(locationTracker)
-                .environmentObject(userRedirectionSettings)
-                .environmentObject(dependancies.airBeamConnectionController)
-                .environment(\.managedObjectContext, persistenceController.viewContext)
-        }
+struct MainAppView: View {
+    
+    let airBeamConnectionController: DefaultAirBeamConnectionController
+    let sessionSynchronizer: SessionSynchronizer
+    private let measurementStreamStorage: MeasurementStreamStorage = CoreDataMeasurementStreamStorage(persistenceController: PersistenceController.shared)
+    @EnvironmentObject var persistenceController: PersistenceController
+    @EnvironmentObject var urlProvider: UserDefaultsBaseURLProvider
+    @EnvironmentObject var userAuthenticationSession: UserAuthenticationSession
+    
+    var body: some View {
+        MainTabBarView(measurementUpdatingService: DownloadMeasurementsService(
+                        authorisationService: userAuthenticationSession,
+                        persistenceController: persistenceController,
+                        baseUrl: urlProvider), urlProvider: urlProvider, measurementStreamStorage: measurementStreamStorage, sessionSynchronizer: sessionSynchronizer, sessionContext: CreateSessionContext())
+            .environmentObject(airBeamConnectionController)
+    }
 }
 
 #if DEBUG

--- a/AirCasting/RootAppView.swift
+++ b/AirCasting/RootAppView.swift
@@ -49,7 +49,7 @@ struct RootAppView: View {
         .environmentObject(urlProvider)
         .environment(\.managedObjectContext, persistenceController.viewContext)
         .onAppear {
-            airBeamConnectionController =  DefaultAirBeamConnectionController(connectingAirBeamServices: ConnectingAirBeamServicesBluetooth(bluetoothConnector: bluetoothManager))
+            airBeamConnectionController = DefaultAirBeamConnectionController(connectingAirBeamServices: ConnectingAirBeamServicesBluetooth(bluetoothConnector: bluetoothManager))
         }
     }
     

--- a/AirCasting/URLProviders/UserDefaultsBaseURLProvider.swift
+++ b/AirCasting/URLProviders/UserDefaultsBaseURLProvider.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-class UserDefaultsBaseURLProvider: BaseURLProvider {
+class UserDefaultsBaseURLProvider: BaseURLProvider, ObservableObject {
     var baseAppURL: URL {
         set {
             userDefaults.set(newValue, forKey: "baseURL")

--- a/AirCasting/Utils/SystemSettings.swift
+++ b/AirCasting/Utils/SystemSettings.swift
@@ -6,7 +6,7 @@ import SwiftUI
 
 protocol SettingsRedirection {
     func goToLocationAuthSettings()
-    func goToBluetoothAuthSettings()
+    func goToAppsBluetoothAuthSettings()
 }
 
 extension SettingsRedirection {
@@ -19,8 +19,17 @@ extension SettingsRedirection {
         }
     }
     
-    func goToBluetoothAuthSettings() {
+    func goToAppsBluetoothAuthSettings() {
         if let url = URL(string: UIApplication.openSettingsURLString) {
+            let app = UIApplication.shared
+            if app.canOpenURL(url) {
+                app.open(url, options: [:], completionHandler: nil)
+            }
+        }
+    }
+    
+    func goToBluetoothAuthSettings() {
+        if let url = URL(string: "App-prefs:root=Bluetooth") {
             let app = UIApplication.shared
             if app.canOpenURL(url) {
                 app.open(url, options: [:], completionHandler: nil)


### PR DESCRIPTION
Bug: There's no "Turn on Bluetooth" view even if the Bluetooth was powered off. The app allowed me to go to select device view and it was "searching" for devices even though Bluetooth was off.

I had to remove Dependencies and refactored RootAppView.swift. It wasn't the first time it caused hard-to-find bugs, so I decided to fix it for the future. And it was one of the reasons why the TurnOnBluetoothView was displayed when Bluetooth was on and authorized. :) 