### PR TITLE
Map button - outdoor

### DIFF
--- a/AirCasting/SessionViews/SessionCartView.swift
+++ b/AirCasting/SessionViews/SessionCartView.swift
@@ -126,7 +126,7 @@ private extension SessionCartView {
                 followButton
             }
             Spacer()
-            if !session.isIndoor && session.type != .fixed {
+            if !session.isIndoor {
                 mapButton(thresholds: thresholds)
             }
             graphButton(thresholds: thresholds)


### PR DESCRIPTION
In addition to this: https://github.com/HabitatMap/AirCastingiOS/pull/157 

After those two tickets isIndoor will be handled in every case, so that in this ticket we are able to shorten IF

https://trello.com/c/jp738Egu/221-fixed-outdoor-dashboard-map-button-is-missing