### PR TITLE
ContributToCrowdMap fix 

### DIFF
--- a/AirCasting/AuthViews/UserSettings.swift
+++ b/AirCasting/AuthViews/UserSettings.swift
@@ -6,15 +6,18 @@ import Foundation
 class UserSettings: ObservableObject {
     private let userDefaults: UserDefaults
     
-    @Published var contributingToCrowdMap: Bool {
-        didSet {
-            Log.info("Changed crowdmap contribution setting to \(contributingToCrowdMap ? "ON" : "OFF")")
-            userDefaults.setValue(contributingToCrowdMap, forKey: "crowdMap")
+    var contributingToCrowdMap: Bool {
+        get {
+            userDefaults.bool(forKey: "crowdMap")
+        }
+        set {
+            userDefaults.setValue(newValue, forKey: "crowdMap")
+            Log.info("Changed crowdMap contribution setting to \(contributingToCrowdMap ? "ON" : "OFF")")
         }
     }
     
     init(userDefaults: UserDefaults = .standard) {
-        self.contributingToCrowdMap = userDefaults.bool(forKey: "crowdMap")
         self.userDefaults = userDefaults
+        contributingToCrowdMap = true
     }
 }

--- a/AirCasting/CreateSessionViews/CreateSessionDetailsView.swift
+++ b/AirCasting/CreateSessionViews/CreateSessionDetailsView.swift
@@ -161,21 +161,19 @@ private extension CreateSessionDetailsView {
         if sessionContext.sessionType == .fixed {
             if isIndoor {
                 sessionContext.startingLocation = fakeLocation
-                locationTracker.googleLocation = [PathPoint(location: CLLocationCoordinate2D(latitude: 200.0, longitude: 200.0), measurement: 20.0)]
-                // measurement: 20.0 was designed just to be 'something'. Is should be handle somehow, but for now we are leaving this like it is.
+                locationTracker.googleLocation = [PathPoint.fakePathPoint]
             } else {
                 guard let lat = (locationTracker.locationManager.location?.coordinate.latitude),
                       let lon = (locationTracker.locationManager.location?.coordinate.longitude) else { return }
-                locationTracker.googleLocation = [PathPoint(location: CLLocationCoordinate2D(latitude: lat, longitude: lon), measurement: 20.0)]
+                locationTracker.googleLocation = [PathPoint.fakePathPoint]
                 #warning("Do something with exposed googleLocation")
-                // measurement: 20.0 was designed just to be 'something'. Is should be handle somehow, but for now we are leaving this like it is.
                 sessionContext.obtainCurrentLocation(lat: lat, log: lon)
             }
         } else {
             guard let lat = (locationTracker.locationManager.location?.coordinate.latitude),
                   let lon = (locationTracker.locationManager.location?.coordinate.longitude) else { return }
             locationTracker.googleLocation = [PathPoint(location: CLLocationCoordinate2D(latitude: lat, longitude: lon), measurement: 20.0)]
-            // measurement: 20.0 was designed just to be 'something'. Is should be handle somehow, but for now we are leaving this like it is.
+            #warning("Do something with hard coded measurement")
             sessionContext.obtainCurrentLocation(lat: lat, log: lon)
         }
     }

--- a/AirCasting/CreateSessionViews/PlacePicker.swift
+++ b/AirCasting/CreateSessionViews/PlacePicker.swift
@@ -42,7 +42,7 @@ struct PlacePicker: UIViewControllerRepresentable {
             DispatchQueue.main.async { [self] in
                 print(place.description.description as Any)
                 self.parent.address =  place.name!
-                parent.tracker.googleLocation = [PathPoint(location: place.coordinate, measurement: 20.0)]
+                parent.tracker.googleLocation = [PathPoint.fakePathPoint]
                 self.parent.presentationMode.wrappedValue.dismiss()
             }
         }

--- a/AirCasting/Map/GoogleMapView.swift
+++ b/AirCasting/Map/GoogleMapView.swift
@@ -124,6 +124,7 @@ struct GoogleMapView: UIViewRepresentable {
             let lat = mapView.projection.coordinate(for: mapView.center).latitude
             let len = mapView.projection.coordinate(for: mapView.center).longitude
             parent.tracker.googleLocation = [PathPoint(location: CLLocationCoordinate2D(latitude: lat, longitude: len), measurement: 20.0)]
+            #warning("Do something with hard coded measurement")
         }
 
         var didSetInitLocation: Bool = false   

--- a/AirCasting/Map/LocationTracker.swift
+++ b/AirCasting/Map/LocationTracker.swift
@@ -21,7 +21,11 @@ class LocationTracker: NSObject, ObservableObject, CLLocationManagerDelegate {
         switch locationManager.authorizationStatus {
             case .authorizedAlways, .authorizedWhenInUse:
                 self.locationGranted = .granted
-                googleLocation = [PathPoint(location: CLLocationCoordinate2D(latitude: (locationManager.location?.coordinate.latitude)!, longitude: (locationManager.location?.coordinate.longitude)!), measurement: 20)]
+                if locationManager.location?.coordinate.latitude != nil && locationManager.location?.coordinate.longitude != nil {
+                    googleLocation = [PathPoint(location: CLLocationCoordinate2D(latitude: (locationManager.location?.coordinate.latitude)!, longitude: (locationManager.location?.coordinate.longitude)!), measurement: 20)]
+                } else {
+                    googleLocation = [PathPoint(location: CLLocationCoordinate2D(latitude: 200.0, longitude: 200.0), measurement: 20)]
+                }
             case .denied, .notDetermined, .restricted:
                 self.locationGranted = .denied
                 googleLocation = [PathPoint(location: CLLocationCoordinate2D(latitude: 37.35, longitude: -122.05), measurement: 20.0)]

--- a/AirCasting/Map/LocationTracker.swift
+++ b/AirCasting/Map/LocationTracker.swift
@@ -24,12 +24,12 @@ class LocationTracker: NSObject, ObservableObject, CLLocationManagerDelegate {
                 if locationManager.location?.coordinate.latitude != nil && locationManager.location?.coordinate.longitude != nil {
                     googleLocation = [PathPoint(location: CLLocationCoordinate2D(latitude: (locationManager.location?.coordinate.latitude)!, longitude: (locationManager.location?.coordinate.longitude)!), measurement: 20)]
                 } else {
-                    googleLocation = [PathPoint(location: CLLocationCoordinate2D(latitude: 200.0, longitude: 200.0), measurement: 20)]
+                    googleLocation = [PathPoint.fakePathPoint]
                 }
             case .denied, .notDetermined, .restricted:
                 self.locationGranted = .denied
                 googleLocation = [PathPoint(location: CLLocationCoordinate2D(latitude: 37.35, longitude: -122.05), measurement: 20.0)]
-        // measurement: 20.0 was designed just to be 'something'. Is should be handle somehow, but for now we are leaving this like it is.
+                #warning("Do something with hard coded measurement")
             @unknown default:
                 fatalError()
         }

--- a/AirCasting/Map/PathPoint.swift
+++ b/AirCasting/Map/PathPoint.swift
@@ -12,3 +12,7 @@ struct PathPoint {
     let location: CLLocationCoordinate2D
     let measurement: Double
 }
+
+extension PathPoint {
+    static var fakePathPoint = PathPoint(location: CLLocationCoordinate2D(latitude: 200.0, longitude: 200.0), measurement: 20.0)
+}

--- a/AirCasting/Settings/SettingsView.swift
+++ b/AirCasting/Settings/SettingsView.swift
@@ -70,14 +70,11 @@ struct SettingsView: View {
     private var crowdMapTitle: some View {
         Text(Strings.Settings.crowdMap)
             .font(Font.muli(size: 16, weight: .bold))
-            .padding(.bottom, 14)
+            .multilineTextAlignment(.leading)
     }
     
     private var crowdMapSwitch: some View {
         Toggle(isOn: $userSettings.contributingToCrowdMap) {
-            Text("Switch")
-                .font(.title)
-                .foregroundColor(Color.white)
         }.toggleStyle(SwitchToggleStyle(tint: .accentColor))
     }
     


### PR DESCRIPTION
What was done:

https://trello.com/c/XkbtqPbo/116-settings-contribute-to-crowd-map

Now the default state of the toggle is "ON"
UI - text is now well laid
Ensured that contriuteToCrowdMap changes all the time and the proper state is sent during the session creation process