### PR TITLE
wifi to the left

### DIFF
--- a/AirCasting/CreateSessionViews/CreateSessionDetailsView.swift
+++ b/AirCasting/CreateSessionViews/CreateSessionDetailsView.swift
@@ -14,7 +14,7 @@ struct CreateSessionDetailsView: View {
     @State var sessionName: String = ""
     @State var sessionTags: String = ""
     @State var isIndoor = true
-    @State var isWiFi = false
+    @State var isWiFi = true
     @State var adress = ""
     @State var isWifiPopupPresented = false
     @State var isLocationPopupPresented = false
@@ -142,8 +142,8 @@ private extension CreateSessionDetailsView {
                 .foregroundColor(.aircastingDarkGray)
             Picker(selection: $isWiFi,
                    label: Text("")) {
-                Text(Strings.CreateSessionDetailsView.cellularText).tag(false)
                 Text(Strings.CreateSessionDetailsView.wifiText).tag(true)
+                Text(Strings.CreateSessionDetailsView.cellularText).tag(false)
             }
             .pickerStyle(SegmentedPickerStyle())
             .onChange(of: isWiFi) { _ in


### PR DESCRIPTION
https://trello.com/c/ZRoqJXu3/244-fixed-wizard-move-wifi-to-the-left-make-it-the-default-selection

What was done:
Although the wifi is picked now as the default we are somehow ensure that user type the password because the wifi warning popup will appear 

Changes Wifi and cellular 