### PR TITLE
Add bluetooth-central Background Execution Mode

### DIFF
--- a/AirCasting/Info.plist
+++ b/AirCasting/Info.plist
@@ -76,6 +76,7 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
+		<string>bluetooth-central</string>
 	</array>
 	<key>UILaunchScreen</key>
 	<dict/>

--- a/AirCasting/Models/AirBeamFixedSessionCreator.swift
+++ b/AirCasting/Models/AirBeamFixedSessionCreator.swift
@@ -55,7 +55,7 @@ final class AirBeamFixedSessionCreator: SessionCreator {
             return
         }
         
-        #warning("TODO: change mocked data (contribute ✅, is_indoor ✅, notes (not yet), location ✅, end_time ✅)")
+        #warning("TODO: change mocked data -->  notes")
         let params = CreateSessionApi.SessionParams(uuid: sessionUUID,
                                                     type: .fixed,
                                                     title: name,


### PR DESCRIPTION
Can't test it well because it was working properly on my phone before those changes, but app should be able to communicate with AB3 (mobile active sessions) in background. 