### PR TITLE
formatting measurements text

### DIFF
--- a/AirCasting/SessionViews/SingleMeasurementView.swift
+++ b/AirCasting/SessionViews/SingleMeasurementView.swift
@@ -22,6 +22,7 @@ struct SingleMeasurementView: View {
                                          value: value,
                                          selectedStream: $selectedStream,
                                          threshold: threshold)
+                    .scaledToFill()
                 
             }
         }
@@ -53,7 +54,7 @@ struct SingleMeasurementView: View {
                                        thresholds: threshold)
                     Text("\(Int(value))")
                         .font(Font.moderate(size: 14, weight: .regular))
-                        .scaledToFill()
+//                        .scaledToFill()
                 }
             })
             .buttonStyle(AirCastingStyling.BorderedButtonStyle(isSelected: selectedStream == stream,

--- a/AirCasting/SessionViews/SingleMeasurementView.swift
+++ b/AirCasting/SessionViews/SingleMeasurementView.swift
@@ -53,6 +53,7 @@ struct SingleMeasurementView: View {
                                        thresholds: threshold)
                     Text("\(Int(value))")
                         .font(Font.moderate(size: 14, weight: .regular))
+                        .scaledToFill()
                 }
             })
             .buttonStyle(AirCastingStyling.BorderedButtonStyle(isSelected: selectedStream == stream,

--- a/AirCasting/SessionViews/SingleMeasurementView.swift
+++ b/AirCasting/SessionViews/SingleMeasurementView.swift
@@ -15,6 +15,7 @@ struct SingleMeasurementView: View {
         VStack(spacing: 3) {
             Text(showStreamName())
                 .font(Font.system(size: 13))
+                .scaledToFill()
             if measurementPresentationStyle == .showValues,
                let value = value,
                let threshold = threshold {
@@ -22,8 +23,6 @@ struct SingleMeasurementView: View {
                                          value: value,
                                          selectedStream: $selectedStream,
                                          threshold: threshold)
-                    .scaledToFill()
-                
             }
         }
     }
@@ -54,7 +53,7 @@ struct SingleMeasurementView: View {
                                        thresholds: threshold)
                     Text("\(Int(value))")
                         .font(Font.moderate(size: 14, weight: .regular))
-//                        .scaledToFill()
+                        .scaledToFill()
                 }
             })
             .buttonStyle(AirCastingStyling.BorderedButtonStyle(isSelected: selectedStream == stream,


### PR DESCRIPTION
It comes out that one line will do the job (Heh) 

https://trello.com/c/kUfhVyt0/236-all-tabs-double-digit-measurements-break-the-formatting