### PR TITLE
Add dot to mobile session's map

### DIFF
--- a/AirCasting/Map/GoogleMapView.swift
+++ b/AirCasting/Map/GoogleMapView.swift
@@ -55,20 +55,31 @@ struct GoogleMapView: UIViewRepresentable {
     func updateUIView(_ uiView: GMSMapView, context: Context) {
         // Drawing the path
         let path = GMSMutablePath()
+        let dot = context.coordinator.dot
+        
         for point in pathPoints {
             let coordinate = point.location
             path.add(coordinate)
+            
+            dot.position = coordinate
+            dot.iconView = UIView()
+            dot.iconView?.frame = CGRect(x: 0, y: 0,
+                                         width: Constants.Map.dotWidth,
+                                         height: Constants.Map.dotHeight)
+            dot.iconView?.layer.cornerRadius = CGFloat(Constants.Map.dotRadius)
+            dot.iconView?.backgroundColor = color(point: point)
+            dot.map = uiView
         }
         let polyline = context.coordinator.polyline
         let spans = pathPoints.map { point -> GMSStyleSpan in
-            let color = colorPolyline(point: point)
+            let color = color(point: point)
             return GMSStyleSpan(style: GMSStrokeStyle.solidColor(color),
                                 segments: 1)
         }
 
         polyline.path = path
         polyline.spans = spans
-        polyline.strokeWidth = CGFloat(Constants.Polyline.width)
+        polyline.strokeWidth = CGFloat(Constants.Map.polylineWidth)
         polyline.map = uiView
         
         // Update camera's starting point
@@ -108,7 +119,7 @@ struct GoogleMapView: UIViewRepresentable {
         }
     }
 
-    func colorPolyline(point: PathPoint) -> UIColor {
+    func color(point: PathPoint) -> UIColor {
         let measurement = Int32(point.measurement)
         guard let thresholds = threshold else { return .white }
         
@@ -136,6 +147,7 @@ struct GoogleMapView: UIViewRepresentable {
 
         var parent: GoogleMapView!
         let polyline = GMSPolyline()
+        let dot = GMSMarker()
         
         init(_ parent: GoogleMapView) {
             self.parent = parent

--- a/AirCasting/Utils/Constants.swift
+++ b/AirCasting/Utils/Constants.swift
@@ -8,7 +8,10 @@ struct Constants {
         static let microphone = "Phone Microphone"
     }
     
-    enum Polyline {
-        static let width = 15
+    enum Map {
+        static let polylineWidth = 5
+        static let dotRadius = 10
+        static let dotWidth = 20
+        static let dotHeight = 20
     }
 }


### PR DESCRIPTION
Michael asked to make the polyline thinner & and a dot at the end of the polyline. I decided to use GMSMarker instead of GMSCircle because GMSCircle doesn't change its width when scaling the map so it's invisible after zoom out.
Task: https://trello.com/c/jv3Hk6EG/227-mobile-map-improve-mapping-visualization