### PR TITLE
Chart fix

### DIFF
--- a/AirCasting/SessionViews/ChartView.swift
+++ b/AirCasting/SessionViews/ChartView.swift
@@ -97,7 +97,8 @@ struct ChartView: UIViewRepresentable {
         //dots colors
         dataSet.circleColors = generateColorsSet(for: dataSet.entries)
         dataSet.drawCircleHoleEnabled = false
-        dataSet.circleRadius = 6
+        dataSet.circleRadius = 4
+
         
         //line color
         dataSet.setColor(UIColor.aircastingGray.withAlphaComponent(0.7))

--- a/AirCasting/SessionViews/SessionCartView.swift
+++ b/AirCasting/SessionViews/SessionCartView.swift
@@ -219,7 +219,7 @@ private extension SessionCartView {
                     HStack() {
                             Text(startTime)
                             Spacer()
-                        Text("\(Strings.SessionCartView.avgSession) \(selectedStream.measurementShortType ?? "")")
+                        Text("\(Strings.SessionCartView.avgSession) \(selectedStream.unitSymbol ?? "")")
                             Spacer()
                             Text(endTime)
                     }.foregroundColor(.aircastingGray)


### PR DESCRIPTION
Michael added: 

-shrink chart dots
-y-axis label should display the "Unit symbol/abbreviation" not the "Short type of measurement", e.g. for RH the label should read "1 hr avg - %"