### PR TITLE
Added ability to cut out UI updates from storage (Core Data stack)

### DIFF
--- a/AirCasting.xcodeproj/project.pbxproj
+++ b/AirCasting.xcodeproj/project.pbxproj
@@ -179,6 +179,7 @@
 		B38E6CD226C5F85000C21C45 /* SyncTriggeringSesionStopperProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B38E6CD126C5F85000C21C45 /* SyncTriggeringSesionStopperProxy.swift */; };
 		B3AB8BE526BB5EF400AF23CC /* Array+MeasurementStatistics.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AB8BE426BB5EF400AF23CC /* Array+MeasurementStatistics.swift */; };
 		B3C3F8B92695A295003E2CB4 /* StatisticsContainerViewModelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C3F8B82695A295003E2CB4 /* StatisticsContainerViewModelable.swift */; };
+		B3D1928D26F1FA1C0029E1C8 /* FixedSessionFaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3EFAB1D26F1F9DB00E88141 /* FixedSessionFaker.swift */; };
 		B3D4B4B426C2C6A1004322FC /* Date+Miliseconds.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D4B4B326C2C6A1004322FC /* Date+Miliseconds.swift */; };
 		B3E26A032676D9AA001A8E4C /* ArrayUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E26A022676D9AA001A8E4C /* ArrayUtils.swift */; };
 		B3E26A062676DA23001A8E4C /* ArrayExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E26A052676DA23001A8E4C /* ArrayExtensionsTests.swift */; };
@@ -477,6 +478,7 @@
 		B3EFAB1426EFE2D200E88141 /* AppBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBootstrap.swift; sourceTree = "<group>"; };
 		B3EFAB1626EFE2DB00E88141 /* FirstRunInfoProvidable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstRunInfoProvidable.swift; sourceTree = "<group>"; };
 		B3EFAB1B26EFEA8B00E88141 /* AppBootstrapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBootstrapTests.swift; sourceTree = "<group>"; };
+		B3EFAB1D26F1F9DB00E88141 /* FixedSessionFaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedSessionFaker.swift; sourceTree = "<group>"; };
 		B3F1447326ADF8A7006A4612 /* ScheduledTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledTimer.swift; sourceTree = "<group>"; };
 		B3F1447526AE0BD4006A4612 /* SessionSynchronizerErrorStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionSynchronizerErrorStream.swift; sourceTree = "<group>"; };
 		B3F1447726AE4337006A4612 /* FilterErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterErrorTests.swift; sourceTree = "<group>"; };
@@ -800,6 +802,7 @@
 		AC7EB36925A6FB3A00A7F2AF = {
 			isa = PBXGroup;
 			children = (
+				B3EFAB1D26F1F9DB00E88141 /* FixedSessionFaker.swift */,
 				4FB39E0E2621B5C100E5E564 /* Podfile */,
 				AC787D36267B41350034B222 /* Modules */,
 				AC7EB37425A6FB3A00A7F2AF /* AirCasting */,
@@ -1701,6 +1704,7 @@
 				B30BAC022694A89100AE0476 /* StatisticsContainerViewModel.swift in Sources */,
 				B3F1447A26AE436A006A4612 /* FilterErrorPublisher.swift in Sources */,
 				B32D08AF267A6D13006C97ED /* ErasingToVoidPublisher.swift in Sources */,
+				B3D1928D26F1FA1C0029E1C8 /* FixedSessionFaker.swift in Sources */,
 				AC049F7F2604B7AF00398197 /* AuthErorrHandling.swift in Sources */,
 				B3FD77C4267C94AF00E97CC2 /* SessionSynchronizationService.swift in Sources */,
 				B33DB5762686161300ED1344 /* SensorName.swift in Sources */,

--- a/AirCasting/AirCastingApp.swift
+++ b/AirCasting/AirCastingApp.swift
@@ -64,12 +64,8 @@ struct AirCastingApp: App {
             case .active:
                 persistenceController.uiSuspended = false
                 appBecameActive.send()
-            case .background:
+            case .background, .inactive:
                 persistenceController.uiSuspended = true
-                break
-            case .inactive:
-                persistenceController.uiSuspended = true
-                break
             @unknown default:
                 fatalError()
             }

--- a/AirCasting/AirCastingApp.swift
+++ b/AirCasting/AirCastingApp.swift
@@ -28,7 +28,6 @@ struct AirCastingApp: App {
         FirebaseApp.configure()
         #endif
         AppBootstrap(firstRunInfoProvider: lifeTimeEventsProvider, deauthorizable: authorization).bootstrap()
-        
         let synchronizationContextProvider = SessionSynchronizationService(client: URLSession.shared, authorization: authorization, responseValidator: DefaultHTTPResponseValidator())
         let downloadService = SessionDownloadService(client: URLSession.shared, authorization: authorization, responseValidator: DefaultHTTPResponseValidator())
         let uploadService = SessionUploadService(client: URLSession.shared, authorization: authorization, responseValidator: DefaultHTTPResponseValidator())
@@ -42,6 +41,7 @@ struct AirCastingApp: App {
         sessionSynchronizer = ScheduledSessionSynchronizerProxy(controller: unscheduledSyncController,
                                                                 scheduler: DispatchQueue.global())
         microphoneManager = MicrophoneManager(measurementStreamStorage: CoreDataMeasurementStreamStorage(persistenceController: PersistenceController.shared))
+        
         syncScheduler = .init(synchronizer: sessionSynchronizer,
                               appBecameActive: appBecameActive.eraseToAnyPublisher(),
                               periodicTimeInterval: 300,
@@ -62,10 +62,13 @@ struct AirCastingApp: App {
         }.onChange(of: scenePhase) { newScenePhase in
             switch newScenePhase {
             case .active:
+                persistenceController.uiSuspended = false
                 appBecameActive.send()
             case .background:
+                persistenceController.uiSuspended = true
                 break
             case .inactive:
+                persistenceController.uiSuspended = true
                 break
             @unknown default:
                 fatalError()

--- a/AirCasting/CoreData/PersistenceController+Database.swift
+++ b/AirCasting/CoreData/PersistenceController+Database.swift
@@ -7,7 +7,7 @@ import Combine
 
 extension PersistenceController: SessionsFetchable {
     func fetchSessions(constrained: Database.Constraint, completion: @escaping (Result<[Database.Session], Error>) -> Void) {
-        let context = self.newBackgroundContext()
+        let context = self.editContext()
         context.perform {
             let request: NSFetchRequest<SessionEntity> = SessionEntity.fetchRequest()
             if case .predicate(let predicate) = constrained {
@@ -26,7 +26,7 @@ extension PersistenceController: SessionsFetchable {
 
 extension PersistenceController: SessionInsertable {
     func insertSessions(_ sessions: [Database.Session], completion: ((Error?) -> Void)?) {
-        let context = self.newBackgroundContext()
+        let context = self.editContext()
         context.perform {
             sessions.forEach {
                 let sessionEntity = SessionEntity(context: context)
@@ -77,7 +77,7 @@ extension PersistenceController: SessionInsertable {
 
 extension PersistenceController: SessionRemovable {
     func removeSessions(where constraint: Database.Constraint, completion: ((Error?) -> Void)?) {
-        let context = self.newBackgroundContext()
+        let context = self.editContext()
         context.perform {
             let request: NSFetchRequest<SessionEntity> = SessionEntity.fetchRequest()
             if case .predicate(let predicate) = constraint {

--- a/AirCasting/CoreData/PersistenceController.swift
+++ b/AirCasting/CoreData/PersistenceController.swift
@@ -20,14 +20,14 @@ class PersistenceController: ObservableObject {
     
     private(set) lazy var viewContext: NSManagedObjectContext = {
         let ctx = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
-        ctx.parent = mainContext
+        ctx.parent = sourceOfTruthContext
         ctx.automaticallyMergesChangesFromParent = true
         return ctx
     }()
     
     private let container: NSPersistentContainer
     
-    private lazy var mainContext: NSManagedObjectContext = container.newBackgroundContext()
+    private lazy var sourceOfTruthContext: NSManagedObjectContext = container.newBackgroundContext()
 
     init(inMemory: Bool = false) {
         container = NSPersistentContainer(name: "AirCasting")
@@ -53,13 +53,13 @@ class PersistenceController: ObservableObject {
         })
         createInitialMicThreshold(in: viewContext)
         finishMobileSessions()
-        NotificationCenter.default.addObserver(self, selector: #selector(mainContextChanged), name: .NSManagedObjectContextObjectsDidChange, object: self.mainContext)
+        NotificationCenter.default.addObserver(self, selector: #selector(mainContextChanged), name: .NSManagedObjectContextObjectsDidChange, object: self.sourceOfTruthContext)
         NotificationCenter.default.addObserver(self, selector: #selector(appWillClose), name: UIApplication.willTerminateNotification, object: nil)
     }
     
     func editContext() -> NSManagedObjectContext {
         let ctx = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
-        ctx.parent = mainContext
+        ctx.parent = sourceOfTruthContext
         return ctx
     }
     
@@ -94,8 +94,8 @@ class PersistenceController: ObservableObject {
     }
     
     private func saveMainContext() {
-        mainContext.perform {
-            try! self.mainContext.save()
+        sourceOfTruthContext.perform {
+            try! self.sourceOfTruthContext.save()
         }
     }
 

--- a/FixedSessionFaker.swift
+++ b/FixedSessionFaker.swift
@@ -1,0 +1,73 @@
+// Created by Lunar on 15/09/2021.
+//
+
+import Foundation
+import CoreData
+
+class FixedSessionFaker {
+    init(context: NSManagedObjectContext) {
+        let req: NSFetchRequest<SessionEntity> = SessionEntity.fetchRequest()
+        req.predicate = NSPredicate(format: "name LIKE %@", "Its complicated")
+        var session: SessionEntity!
+        if let already = try! context.fetch(req).first {
+            print("A")
+            session = already
+        } else {
+            print("B")
+            session = SessionEntity(context: context)
+            session.type = .fixed
+            session.uuid = SessionUUID()
+            session.name = "Its complicated"
+            session.tags = ""
+            session.startTime = Date(timeIntervalSinceReferenceDate: 23443)
+            session.endTime = Date(timeIntervalSinceReferenceDate: 2344323)
+            session.gotDeleted = false
+            session.version = 32
+            session.status = .RECORDING
+            session.deviceType = .AIRBEAM3
+
+            for i in 0..<5 {
+                let stream = MeasurementStreamEntity(context: context)
+                stream.gotDeleted = false
+                stream.measurementShortType = "S\(i)"
+                stream.measurementType = "S\(i)"
+                stream.sensorName = "S\(i)"
+                stream.sensorPackageName = "S\(i)"
+                stream.thresholdHigh = 100
+                stream.thresholdLow = 10
+                stream.thresholdMedium = 20
+                stream.thresholdVeryHigh = 110
+                stream.thresholdVeryLow = 0
+                stream.unitName = "UNiT"
+                stream.unitSymbol = "UNT"
+                stream.id = .random(in: 0...999)
+                stream.session = session
+                session.addToMeasurementStreams(stream)
+
+                let th = SensorThreshold(context: context)
+                th.sensorName = "S\(i)"
+                th.thresholdLow = 10
+                th.thresholdHigh = 100
+                th.thresholdMedium = 20
+                th.thresholdVeryLow = 0
+                th.thresholdVeryHigh = 110
+            }
+
+            try! context.save()
+        }
+
+        var currId: Int64 = 1
+        Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
+            for stream in session.allStreams ?? [] {
+                let measurement = MeasurementEntity(context: context)
+                measurement.id = currId
+                measurement.time = Date()
+                measurement.value = .random(in: 0...120)
+                measurement.location = .init(latitude: 50.049683, longitude: 19.944544)
+                stream.addToMeasurements(measurement)
+                currId += 1
+            }
+            try! context.save()
+        }
+    }
+}

--- a/FixedSessionFaker.swift
+++ b/FixedSessionFaker.swift
@@ -10,10 +10,8 @@ class FixedSessionFaker {
         req.predicate = NSPredicate(format: "name LIKE %@", "Its complicated")
         var session: SessionEntity!
         if let already = try! context.fetch(req).first {
-            print("A")
             session = already
         } else {
-            print("B")
             session = SessionEntity(context: context)
             session.type = .fixed
             session.uuid = SessionUUID()


### PR DESCRIPTION
## What was done?
Core data stack changed to a parent/child model with a `single source of truth` pattern:
1. Only one, "main" `NSManagedObjectContext` is responsible for writing to the store (and it's a background one)
2. The UI Context as well as edit contexts are children of the main context
3. Changes from the main context to the UI context are being propagated only when the new `uiSuspended` flag is not set

## Technical notes
* `FixedSessionFaker` left in the code - it might be handy (it's faking a running fixed session with random measurements)
### New CD stack structure
![new_coredata](https://user-images.githubusercontent.com/10663361/134420829-717b0645-88f8-4471-9315-9848b7c0e9cd.png)

### Old CD stack structure
![old_coredata](https://user-images.githubusercontent.com/10663361/134420882-2c0e356d-23d3-4359-ab9d-3182337b9504.png)


