### PR TITLE
Refactor to fix app crashing after creating ABmobile session & syncing measurments

### DIFF
--- a/AirCasting/CreateSessionViews/ConfirmCreatingSessionView.swift
+++ b/AirCasting/CreateSessionViews/ConfirmCreatingSessionView.swift
@@ -16,66 +16,63 @@ struct ConfirmCreatingSessionView: View {
             isPresentingAlert = error != nil
         }
     }
-
     @State private var isPresentingAlert: Bool = false
     @EnvironmentObject var selectedSection: SelectSection
     @EnvironmentObject private var sessionContext: CreateSessionContext
     @EnvironmentObject private var locationTracker: LocationTracker
     @EnvironmentObject private var tabSelection: TabBarSelection
     @EnvironmentObject var persistenceController: PersistenceController
-    @EnvironmentObject var bluetoothManager: BluetoothManager
     @EnvironmentObject var userAuthenticationSession: UserAuthenticationSession
     @EnvironmentObject private var microphoneManager: MicrophoneManager
+    @EnvironmentObject var bluetoothManager: BluetoothManager
     @Binding var creatingSessionFlowContinues: Bool
     let baseURL: BaseURLProvider
     var sessionName: String
     private var sessionType: String { (sessionContext.sessionType ?? .fixed).description.lowercased() }
-
+    
     var body: some View {
         LoadingView(isShowing: $isActive) {
             contentViewWithAlert
         }
     }
-
+    
     private var contentViewWithAlert: some View {
         contentView.alert(isPresented: $isPresentingAlert) {
             Alert(title: Text(Strings.ConfirmCreatingSessionView.alertTitle),
                   message: Text(error?.localizedDescription ?? Strings.ConfirmCreatingSessionView.alertMessage),
                   dismissButton: .default(Text(Strings.ConfirmCreatingSessionView.alertOK), action: { error = nil
-                  }))
+            }))
         }
     }
-
+    
     private var defaultDescriptionText: Text {
         Text(Strings.ConfirmCreatingSessionView.contentViewText_1)
-            + Text(sessionType)
+        + Text(sessionType)
             .foregroundColor(.accentColor)
-            + Text(Strings.ConfirmCreatingSessionView.contentViewText_2)
-            + Text(sessionName)
+        + Text(Strings.ConfirmCreatingSessionView.contentViewText_2)
+        + Text(sessionName)
             .foregroundColor(.accentColor)
-            + Text(Strings.ConfirmCreatingSessionView.contentViewText_3)
+        + Text(Strings.ConfirmCreatingSessionView.contentViewText_3)
     }
-
+    
     var dot: some View {
         Capsule()
             .fill(Color.accentColor)
             .frame(width: 15, height: 15)
     }
-
+    
     private var descriptionTextFixed: some View {
         defaultDescriptionText
-            + Text((sessionContext.isIndoor!) ? "" : Strings.ConfirmCreatingSessionView.contentViewText_4)
+        + Text((sessionContext.isIndoor!) ? "" : Strings.ConfirmCreatingSessionView.contentViewText_4)
     }
-
+    
     private var descriptionTextMobile: some View {
         defaultDescriptionText
-            + Text(Strings.ConfirmCreatingSessionView.contentViewText_4Mobile)
+        + Text(Strings.ConfirmCreatingSessionView.contentViewText_4Mobile)
     }
     
     @ViewBuilder private var contentView: some View {
-        
         if let sessionCreator = setSessioonCreator() {
-            
             VStack(alignment: .leading, spacing: 40) {
                 ProgressView(value: 0.95)
                 Text(Strings.ConfirmCreatingSessionView.contentViewTitle)
@@ -104,35 +101,41 @@ struct ConfirmCreatingSessionView: View {
                 Button(action: {
                     getAndSaveStartingLocation()
                     isActive = true
-                    sessionCreator.createSession(sessionContext) { result in
-                        
-                        DispatchQueue.main.async {
-                            switch result {
-                            case .success:
-                                self.creatingSessionFlowContinues = false
-                                if sessionContext.sessionType == .mobile {
-                                    selectedSection.selectedSection = SelectedSection.mobileActive
-                                } else {
-                                    selectedSection.selectedSection = SelectedSection.following
-                                }
-                                tabSelection.selection = TabBarSelection.Tab.dashboard
-                            case .failure(let error):
-                                self.error = error as NSError
-                                Log.warning("Failed to create session \(error)")
-                            }
-                            isActive = false
-                        }
-                    }
+                    createSession(sessionCreator: sessionCreator)
                 }, label: {
                     Text(Strings.ConfirmCreatingSessionView.startRecording)
                         .bold()
                 })
-                .buttonStyle(BlueButtonStyle())
+                    .buttonStyle(BlueButtonStyle())
             }
             .padding()
         }
     }
+}
 
+extension ConfirmCreatingSessionView {
+    
+    func createSession(sessionCreator: SessionCreator) {
+        sessionCreator.createSession(sessionContext) { result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success:
+                    self.creatingSessionFlowContinues = false
+                    if sessionContext.sessionType == .mobile {
+                        selectedSection.selectedSection = SelectedSection.mobileActive
+                    } else {
+                        selectedSection.selectedSection = SelectedSection.following
+                    }
+                    tabSelection.selection = TabBarSelection.Tab.dashboard
+                case .failure(let error):
+                    self.error = error as NSError
+                    Log.warning("Failed to create session \(error)")
+                }
+                isActive = false
+            }
+        }
+    }
+    
     func getAndSaveStartingLocation() {
         if sessionContext.sessionType == .fixed {
             if sessionContext.isIndoor! {
@@ -140,21 +143,19 @@ struct ConfirmCreatingSessionView: View {
             } else {
                 guard let lat: Double = (locationTracker.googleLocation.last?.location.latitude),
                       let lon: Double = (locationTracker.googleLocation.last?.location.longitude) else { return }
-                #warning("Do something with exposed googleLocation")
+#warning("Do something with exposed googleLocation")
                 sessionContext.obtainCurrentLocation(lat: lat, log: lon)
             }
         } else {
             guard let lat = (locationTracker.locationManager.location?.coordinate.latitude),
                   let lon = (locationTracker.locationManager.location?.coordinate.longitude) else { return }
             locationTracker.googleLocation = [PathPoint(location: CLLocationCoordinate2D(latitude: lat, longitude: lon), measurementTime: Date(), measurement: 20.0)]
-            #warning("Do something with hard coded measurement")
+#warning("Do something with hard coded measurement")
             sessionContext.obtainCurrentLocation(lat: lat, log: lon)
         }
     }
-    
     func setSessioonCreator() -> SessionCreator? {
         let isWifi: Bool = (sessionContext.wifiSSID != nil && sessionContext.wifiSSID != nil)
-        
         if sessionContext.sessionType == .fixed && isWifi {
             return AirBeamFixedWifiSessionCreator(
                 measurementStreamStorage: CoreDataMeasurementStreamStorage(persistenceController: persistenceController),
@@ -166,11 +167,15 @@ struct ConfirmCreatingSessionView: View {
                                                  baseUrl: baseURL)
         } else if sessionContext.sessionType == .mobile && sessionContext.deviceType == .MIC {
             return MicrophoneSessionCreator(microphoneManager: microphoneManager)
-        } else {
+        } else if sessionContext.sessionType == .mobile {
             return MobilePeripheralSessionCreator(
                 mobilePeripheralSessionManager: bluetoothManager.mobilePeripheralSessionManager, measurementStreamStorage: CoreDataMeasurementStreamStorage(
                     persistenceController: persistenceController),
                 userAuthenticationSession: userAuthenticationSession)
+        } else {
+            return nil
+            Log.info("Can't set the session creator storage")
         }
     }
+
 }

--- a/AirCasting/CreateSessionViews/CreateSessionDetailsView.swift
+++ b/AirCasting/CreateSessionViews/CreateSessionDetailsView.swift
@@ -23,6 +23,7 @@ struct CreateSessionDetailsView: View {
     @State private var isLocationSessionDetailsActive: Bool = false
     @State private var showingAlert = false
     @EnvironmentObject private var sessionContext: CreateSessionContext
+
     // Location tracker is needed to get wifi SSID (more info CNCopyCurrentNetworkInfo documentation.
     @Binding var creatingSessionFlowContinues: Bool
     let baseURL: BaseURLProvider
@@ -49,7 +50,8 @@ struct CreateSessionDetailsView: View {
                 .padding()
                 .frame(maxWidth: .infinity, minHeight: geometry.size.height, alignment: .top)
             }
-            .background(Group {
+            .background(
+                ZStack {
                 NavigationLink(
                     destination: ChooseCustomLocationView(creatingSessionFlowContinues: $creatingSessionFlowContinues,
                                                           sessionName: $sessionName, baseURL: baseURL),
@@ -58,7 +60,6 @@ struct CreateSessionDetailsView: View {
                         EmptyView()
                     }
                 )
-                NavigationLink("", destination: EmptyView())
                 NavigationLink(
                     destination: ConfirmCreatingSessionView(creatingSessionFlowContinues: $creatingSessionFlowContinues,
                                                             baseURL: baseURL,
@@ -81,6 +82,7 @@ struct CreateSessionDetailsView: View {
 }
 
 private extension CreateSessionDetailsView {
+    
     var continueButton: some View {
         Button(action: {
             sessionContext.sessionName = sessionName
@@ -161,6 +163,4 @@ private extension CreateSessionDetailsView {
             WifiPopupView(wifiPassword: $wifiPassword, wifiSSID: $wifiSSID)
         }
     }
-    
-
 }

--- a/AirCasting/Models/AirBeamCellularSessionCreator.swift
+++ b/AirCasting/Models/AirBeamCellularSessionCreator.swift
@@ -70,16 +70,18 @@ final class AirBeamCellularSessionCreator: SessionCreator {
                                                             DispatchQueue.main.async {
                                                                 switch result {
                                                                 case .success(let output):
-                                                                    do {
-                                                                        try measurementStreamStorage.createSession(session)
-                                                                        try AirBeam3Configurator(userAuthenticationSession: userAuthenticationSession,
-                                                                                                 peripheral: peripheral).configureFixedCellularSession(uuid: sessionUUID,
-                                                                                                                                                       location: sessionContext.startingLocation ?? CLLocationCoordinate2D(latitude: 200, longitude: 200),
-                                                                                                                                                       date: Date())
-                                                                        Log.warning("Created fixed cellular session \(output)")
-                                                                        completion(.success(()))
-                                                                    } catch {
-                                                                        completion(.failure(error))
+                                                                    measurementStreamStorage.accessStorage { storage in
+                                                                        do {
+                                                                            try storage.createSession(session)
+                                                                            try AirBeam3Configurator(userAuthenticationSession: userAuthenticationSession,
+                                                                                                     peripheral: peripheral).configureFixedCellularSession(uuid: sessionUUID,
+                                                                                                                                                           location: sessionContext.startingLocation ?? CLLocationCoordinate2D(latitude: 200, longitude: 200),
+                                                                                                                                                           date: Date())
+                                                                            Log.warning("Created fixed cellular session \(output)")
+                                                                            completion(.success(()))
+                                                                        } catch {
+                                                                            completion(.failure(error))
+                                                                        }
                                                                     }
                                                                 case .failure(let error):
                                                                     Log.warning("Failed to create fixed cellular session \(error)")

--- a/AirCasting/Models/AirBeamFixedWifiSessionCreator.swift
+++ b/AirCasting/Models/AirBeamFixedWifiSessionCreator.swift
@@ -75,19 +75,21 @@ final class AirBeamFixedWifiSessionCreator: SessionCreator {
                                                             DispatchQueue.main.async {
                                                                 switch result {
                                                                 case .success(let output):
-                                                                    do {
-                                                                        try measurementStreamStorage.createSession(session)
-                                                                        try AirBeam3Configurator(userAuthenticationSession: userAuthenticationSession,
-                                                                                                 peripheral: peripheral).configureFixedWifiSession(
-                                                                                                    uuid: sessionUUID,
-                                                                                                    location: sessionContext.startingLocation ?? CLLocationCoordinate2D(latitude: 200, longitude: 200),
-                                                                                                    date: Date(),
-                                                                                                    wifiSSID: wifiSSID,
-                                                                                                    wifiPassword: wifiPassword)
-                                                                        Log.warning("Created fixed Wifi session \(output)")
-                                                                        completion(.success(()))
-                                                                    } catch {
-                                                                        completion(.failure(error))
+                                                                    measurementStreamStorage.accessStorage { storage in
+                                                                        do {
+                                                                            try storage.createSession(session)
+                                                                            try AirBeam3Configurator(userAuthenticationSession: userAuthenticationSession,
+                                                                                                     peripheral: peripheral).configureFixedWifiSession(
+                                                                                                        uuid: sessionUUID,
+                                                                                                        location: sessionContext.startingLocation ?? CLLocationCoordinate2D(latitude: 200, longitude: 200),
+                                                                                                        date: Date(),
+                                                                                                        wifiSSID: wifiSSID,
+                                                                                                        wifiPassword: wifiPassword)
+                                                                            Log.warning("Created fixed Wifi session \(output)")
+                                                                            completion(.success(()))
+                                                                        } catch {
+                                                                            completion(.failure(error))
+                                                                        }
                                                                     }
                                                                 case .failure(let error):
                                                                     Log.warning("Failed to create fixed Wifi session \(error)")

--- a/AirCasting/Models/SessionCreator.swift
+++ b/AirCasting/Models/SessionCreator.swift
@@ -94,7 +94,7 @@ final class MobilePeripheralSessionCreator: SessionCreator {
                                  peripheral: peripheral).configureMobileSession(
                                     date: Date(),
                                     location: sessionContext.startingLocation ?? CLLocationCoordinate2D(latitude: 200, longitude: 200))
-            try mobilePeripheralSessionManager.startRecording(session: session, peripheral: peripheral)
+            mobilePeripheralSessionManager.startRecording(session: session, peripheral: peripheral)
             completion(.success(()))
         } catch {
             assertionFailure("Can't start recording mobile bluetooth session: \(error)")

--- a/AirCasting/SessionStopping/MicrophoneSessionStopper.swift
+++ b/AirCasting/SessionStopping/MicrophoneSessionStopper.swift
@@ -17,7 +17,13 @@ class MicrophoneSessionStopper: SessionStoppable {
     func stopSession() throws {
         Log.verbose("Stopping session with uuid \(uuid.rawValue) using microphone session stopper")
         try microphoneManager.stopRecording()
-        try measurementStreamStorage.updateSessionEndtime(Date(), for: uuid)
-        try measurementStreamStorage.updateSessionStatus(.FINISHED, for: uuid)
+        measurementStreamStorage.accessStorage { [self] storage in
+            do {
+                try storage.updateSessionEndtime(Date(), for: self.uuid)
+                try storage.updateSessionStatus(.FINISHED, for: self.uuid)
+            } catch {
+                Log.info("\(error)")
+            }
+        }
     }
 }

--- a/AirCasting/SessionViews/SessionCartFollowing.swift
+++ b/AirCasting/SessionViews/SessionCartFollowing.swift
@@ -30,7 +30,11 @@ extension SessionFollowing {
              return session.followedAt != nil ? .following : .notFollowing
          }
          set {
-             measurementStreamStorage.updateSessionFollowing(newValue, for: session.uuid)
+             #warning("❌This 'setter' is asynchronous!!!")
+             let id = self.session.uuid!
+             measurementStreamStorage.accessStorage { storage in
+                 storage.updateSessionFollowing(newValue, for: id)
+             }
          }
      }
  }

--- a/AirCastingTests/Logic/SessionsSynchronization/SynchronizationTestMocks.swift
+++ b/AirCastingTests/Logic/SessionsSynchronization/SynchronizationTestMocks.swift
@@ -99,6 +99,7 @@ extension SessionsSynchronization.SessionStoreSessionData: TestDefaultProviding 
 extension SessionsSynchronization.MeasurementStreamDownstreamData {
     static func mock() -> Self {
         .init(id: 54321,
+              size: 11,
               sensorName: "Phone Microphone",
               sensorPackageName: "Builtin",
               unitName: "decibels",


### PR DESCRIPTION
Long story short I added an `accessStorage` which ensures thread-safety by dispatching all calls to the queue owned by the NSManagedObjectContext. This way app won't crash on creating a mobile AB session, the graph is being drawn, measurement can be synced, etc. 