### PR TITLE
Popping navigation stack when in mapview and going background

### DIFF
--- a/AirCasting/Map/AirMapView.swift
+++ b/AirCasting/Map/AirMapView.swift
@@ -11,6 +11,9 @@ import Foundation
 import CoreData
 
 struct AirMapView: View {
+    @Environment(\.scenePhase) var scenePhase
+    @Environment(\.presentationMode) var presentationMode
+    
     var thresholds: [SensorThreshold]
     @StateObject var statsContainerViewModel: StatisticsContainerViewModel
     @StateObject var mapStatsDataSource: MapStatsDataSource
@@ -71,6 +74,13 @@ struct AirMapView: View {
             }
         }
         .navigationBarTitleDisplayMode(.inline)
+        .onChange(of: scenePhase) { phase in
+            switch phase {
+            case .background, .inactive: self.presentationMode.wrappedValue.dismiss()
+            case .active: break
+            @unknown default: fatalError()
+            }
+        }
         .padding()
     }
 }


### PR DESCRIPTION
When user leaves the app while in map view it will pop to prevent major CPU usage and app kill. **This is a bandaid solution**