### PR TITLE
making heatmap settings not to go back

### DIFF
--- a/AirCasting/MainTabBarView.swift
+++ b/AirCasting/MainTabBarView.swift
@@ -56,7 +56,7 @@ private extension MainTabBarView {
     private var dashboardTab: some View {
         NavigationView {
             DashboardView(coreDataHook: CoreDataHook(context: persistenceController.viewContext), measurementStreamStorage: measurementStreamStorage, sessionStoppableFactory: sessionStoppableFactory)
-        }
+        }.navigationViewStyle(StackNavigationViewStyle())
         .tabItem {
             Image(dashboardImage)
         }


### PR DESCRIPTION
Now when you enter the HeatMap setting from Graph or a Map it immediately goes back - it shouldn't now 