### PR TITLE
Remove padding to center measurements names with dots and values

### DIFF
--- a/AirCasting/SessionViews/SingleMeasurementView.swift
+++ b/AirCasting/SessionViews/SingleMeasurementView.swift
@@ -15,7 +15,6 @@ struct SingleMeasurementView: View {
         VStack(spacing: 3) {
             Text(showStreamName())
                 .font(Font.system(size: 13))
-                .padding(.leading, 10)
                 .scaledToFill()
             if measurementPresentationStyle == .showValues,
                let value = value,


### PR DESCRIPTION
Removing the padding on text in singleMeasurementView fixes an issue with measurement values and dots not being aligned with the name.