### PR TITLE
Syncing measurements for dormant sessions - fixes

### DIFF
--- a/AirCasting/CoreData/MeasurementStreamStorage.swift
+++ b/AirCasting/CoreData/MeasurementStreamStorage.swift
@@ -26,7 +26,6 @@ protocol MeasurementStreamStorageContextUpdate {
 extension HiddenCoreDataMeasurementStreamStorage {
     func addMeasurementValue(_ value: Double, at location: CLLocationCoordinate2D? = nil, toStreamWithID id: MeasurementStreamLocalID) throws {
         try addMeasurement(Measurement(time: Date(), value: value, location: location), toStreamWithID: id)
-        try save()
     }
 }
 

--- a/AirCasting/MicrophoneSession/MicrophoneManager.swift
+++ b/AirCasting/MicrophoneSession/MicrophoneManager.swift
@@ -116,7 +116,6 @@ private extension MicrophoneManager {
         measurementStreamStorage.accessStorage { storage in
             do {
                 try storage.addMeasurementValue(decibels, at: location, toStreamWithID: self.measurementStreamLocalID!)
-                try storage.save()
             } catch {
                 Log.info("\(error)")
             }

--- a/AirCasting/MobilePeripheralSessionManager.swift
+++ b/AirCasting/MobilePeripheralSessionManager.swift
@@ -76,7 +76,6 @@ class MobilePeripheralSessionManager {
                     return try self.createSessionStream(stream, sessionUUID)
                 }
                 try storage.addMeasurementValue(stream.measuredValue, at: location, toStreamWithID: id)
-                try storage.save()
             } catch {
                 Log.info("\(error)")
             }
@@ -103,7 +102,6 @@ class MobilePeripheralSessionManager {
             do {
                 streamsIDs[stream.sensorName] = try storage.createMeasurementStream(sessionStream, for: sessionUUID)
                 try storage.addMeasurementValue(stream.measuredValue, at: location, toStreamWithID: streamsIDs[stream.sensorName]!)
-                try storage.save()
             } catch {
                 Log.info("\(error)")
             }

--- a/AirCasting/SessionViews/ABMeasurementsView.swift
+++ b/AirCasting/SessionViews/ABMeasurementsView.swift
@@ -68,7 +68,8 @@ struct _ABMeasurementsView: View {
                                     SingleMeasurementView(stream: stream,
                                                           threshold: threshold,
                                                           selectedStream: _selectedStream,
-                                                          measurementPresentationStyle: measurementPresentationStyle)
+                                                          measurementPresentationStyle: measurementPresentationStyle,
+                                                          isDormant: session.isDormant)
                                 }
                             }
                         }
@@ -113,7 +114,8 @@ struct _ABMeasurementsView: View {
                     SingleMeasurementView(stream: stream,
                                           threshold: nil,
                                           selectedStream: .constant(nil),
-                                          measurementPresentationStyle: .hideValues)
+                                          measurementPresentationStyle: .hideValues,
+                                          isDormant: session.isDormant)
                 }
             }.padding(.horizontal, 8)
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/AirCasting/SessionViews/SingleMeasurementView.swift
+++ b/AirCasting/SessionViews/SingleMeasurementView.swift
@@ -18,7 +18,7 @@ struct SingleMeasurementView: View {
             if measurementPresentationStyle == .showValues,
                let threshold = threshold {
                 _SingleMeasurementButton(stream: stream,
-                                         value: stream.latestValue ?? 0,
+                                         value: session.isDormant ? stream.averageValue : (stream.latestValue ?? 0),
                                          selectedStream: $selectedStream,
                                          threshold: threshold)
             }

--- a/AirCasting/SessionViews/SingleMeasurementView.swift
+++ b/AirCasting/SessionViews/SingleMeasurementView.swift
@@ -9,6 +9,7 @@ struct SingleMeasurementView: View {
     var threshold: SensorThreshold?
     @Binding var selectedStream: MeasurementStreamEntity?
     let measurementPresentationStyle: MeasurementPresentationStyle
+    let isDormant: Bool
     
     var body: some View {
         VStack(spacing: 3) {
@@ -18,7 +19,7 @@ struct SingleMeasurementView: View {
             if measurementPresentationStyle == .showValues,
                let threshold = threshold {
                 _SingleMeasurementButton(stream: stream,
-                                         value: session.isDormant ? stream.averageValue : (stream.latestValue ?? 0),
+                                         value: isDormant ? stream.averageValue : (stream.latestValue ?? 0),
                                          selectedStream: $selectedStream,
                                          threshold: threshold)
             }


### PR DESCRIPTION
Tbh I thought this will be just a first step of fixing the 0-values on dormant sessions but it wasn't. Also, removing save from `addMeasurementValues` improved the performance of saving measurements. 