### PR TITLE
Make stream ObservedObject on SingleMeasurementView

### DIFF
--- a/AirCasting/SessionViews/ABMeasurementsView.swift
+++ b/AirCasting/SessionViews/ABMeasurementsView.swift
@@ -66,7 +66,6 @@ struct _ABMeasurementsView: View {
                             ForEach(streams, id : \.self) { stream in
                                 if let threshold = thresholds.threshold(for: stream) {
                                     SingleMeasurementView(stream: stream,
-                                                          value: stream.latestValue ?? 0,
                                                           threshold: threshold,
                                                           selectedStream: _selectedStream,
                                                           measurementPresentationStyle: measurementPresentationStyle)
@@ -112,7 +111,6 @@ struct _ABMeasurementsView: View {
             Group {
                 ForEach(streamsToShow, id : \.self) { stream in
                     SingleMeasurementView(stream: stream,
-                                          value: nil,
                                           threshold: nil,
                                           selectedStream: .constant(nil),
                                           measurementPresentationStyle: .hideValues)

--- a/AirCasting/SessionViews/SingleMeasurementView.swift
+++ b/AirCasting/SessionViews/SingleMeasurementView.swift
@@ -5,8 +5,7 @@ import SwiftUI
 import AirCastingStyling
 
 struct SingleMeasurementView: View {
-    let stream: MeasurementStreamEntity
-    let value: Double?
+    @ObservedObject var stream: MeasurementStreamEntity
     var threshold: SensorThreshold?
     @Binding var selectedStream: MeasurementStreamEntity?
     let measurementPresentationStyle: MeasurementPresentationStyle
@@ -17,10 +16,9 @@ struct SingleMeasurementView: View {
                 .font(Font.system(size: 13))
                 .scaledToFill()
             if measurementPresentationStyle == .showValues,
-               let value = value,
                let threshold = threshold {
                 _SingleMeasurementButton(stream: stream,
-                                         value: value,
+                                         value: stream.latestValue ?? 0,
                                          selectedStream: $selectedStream,
                                          threshold: threshold)
             }


### PR DESCRIPTION
I'm not sure how it worked previously. Right now we're observing stream on SingleMeasurementView and get value from this observed stream :) 