### PR TITLE
Round time interval to seconds to fix the chart

### DIFF
--- a/AirCasting/Extensions/Date+Miliseconds.swift
+++ b/AirCasting/Extensions/Date+Miliseconds.swift
@@ -24,4 +24,10 @@ extension Date {
         dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         return dateFormatter.date(from: stringDate)!
     }
+
+    var roundedToSecond: Date {
+        let date = self
+        let diff = 1000000000 - Calendar.current.component(.nanosecond, from: date)
+        return Calendar.current.date(byAdding: .nanosecond, value: diff, to: date)!
+    }
 }

--- a/AirCasting/SessionViews/ChartEntriesCreator.swift
+++ b/AirCasting/SessionViews/ChartEntriesCreator.swift
@@ -40,8 +40,17 @@ final class ChartEntriesCreator {
     }
     
     private func averagedValue(_ intervalStart: Date, _ intervalEnd: Date) -> Double? {
-        let measurements = stream.getMeasurementsFromTimeRange(intervalStart, intervalEnd)
+        let measurements = stream.getMeasurementsFromTimeRange(intervalStart.roundedToSecond, intervalEnd.roundedToSecond)
         let values = measurements.map { $0.value}
         return values.isEmpty ? nil : round(values.reduce(0, +)/Double(values.count))
     }
 }
+
+extension Date {
+    var roundedToSecond: Date {
+        let date = self
+        let diff = 1000000000 - Calendar.current.component(.nanosecond, from: date)
+        return Calendar.current.date(byAdding: .nanosecond, value: diff, to: date)!
+    }
+}
+

--- a/AirCasting/SessionViews/ChartEntriesCreator.swift
+++ b/AirCasting/SessionViews/ChartEntriesCreator.swift
@@ -45,12 +45,3 @@ final class ChartEntriesCreator {
         return values.isEmpty ? nil : round(values.reduce(0, +)/Double(values.count))
     }
 }
-
-extension Date {
-    var roundedToSecond: Date {
-        let date = self
-        let diff = 1000000000 - Calendar.current.component(.nanosecond, from: date)
-        return Calendar.current.date(byAdding: .nanosecond, value: diff, to: date)!
-    }
-}
-


### PR DESCRIPTION
Rounding beginning and end of each time interval seems to fix the problem with "dancing chart" (varying number of measurements included in the time interval).