### PR TITLE
Mobile sessions averaging [WIP]

### DIFF
--- a/AirCasting.xcodeproj/project.pbxproj
+++ b/AirCasting.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		AC4EC6BC25B5ABB700C1E312 /* StatisticsContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4EC6BB25B5ABB700C1E312 /* StatisticsContainerView.swift */; };
 		AC4EC6C125B6F18A00C1E312 /* EditButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4EC6C025B6F18A00C1E312 /* EditButtonView.swift */; };
 		AC4EC6C425B6FE0D00C1E312 /* HeatmapSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4EC6C325B6FE0D00C1E312 /* HeatmapSettingsView.swift */; };
+		AC5226C3270C50520048A585 /* Algorithms in Frameworks */ = {isa = PBXBuildFile; productRef = AC5226C2270C50520048A585 /* Algorithms */; };
 		AC524A6F261329330061AD45 /* SessionExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC524A6E261329330061AD45 /* SessionExtension.swift */; };
 		AC524A7626133A370061AD45 /* MeaurementStreamExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC524A7526133A370061AD45 /* MeaurementStreamExtension.swift */; };
 		AC524A892614733D0061AD45 /* CreatingSessionFlowRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC524A882614733D0061AD45 /* CreatingSessionFlowRootView.swift */; };
@@ -247,6 +248,7 @@
 		DD8C380C2689A3DA00901FDF /* BaseURLProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD8C380B2689A3DA00901FDF /* BaseURLProvider.swift */; };
 		DD8C380E2689A55A00901FDF /* BackendSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD8C380D2689A55A00901FDF /* BackendSettingsView.swift */; };
 		DD9EBB4E26AFDD2100D51804 /* TurnOnLocationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9EBB4D26AFDD2100D51804 /* TurnOnLocationView.swift */; };
+		DDB44C252704AF830027176E /* AveragingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB44C242704AF830027176E /* AveragingService.swift */; };
 		DDBC156426A0799300982526 /* SystemSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDBC156326A0799300982526 /* SystemSettings.swift */; };
 		DDBC992626A1652A00B0662E /* ForgotPasswordTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDBC992526A1652A00B0662E /* ForgotPasswordTest.swift */; };
 		DDCE5D3626A1F79F0033C211 /* UserSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCE5D3526A1F79F0033C211 /* UserSettings.swift */; };
@@ -534,6 +536,7 @@
 		DD8C380D2689A55A00901FDF /* BackendSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendSettingsView.swift; sourceTree = "<group>"; };
 		DD8C380F268A0E9400901FDF /* ShareViewModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewModal.swift; sourceTree = "<group>"; };
 		DD9EBB4D26AFDD2100D51804 /* TurnOnLocationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnOnLocationView.swift; sourceTree = "<group>"; };
+		DDB44C242704AF830027176E /* AveragingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AveragingService.swift; sourceTree = "<group>"; };
 		DDBC156326A0799300982526 /* SystemSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemSettings.swift; sourceTree = "<group>"; };
 		DDBC992526A1652A00B0662E /* ForgotPasswordTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForgotPasswordTest.swift; sourceTree = "<group>"; };
 		DDCE5D3526A1F79F0033C211 /* UserSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettings.swift; sourceTree = "<group>"; };
@@ -574,6 +577,7 @@
 				AC6D567C25AC540D00D221BA /* Charts in Frameworks */,
 				ACF600BE2678D7F4005DD97C /* SwiftSimplify in Frameworks */,
 				F76B6F660F0BD398629EDD83 /* Pods_AirCasting.framework in Frameworks */,
+				AC5226C3270C50520048A585 /* Algorithms in Frameworks */,
 				AC787D75267B41990034B222 /* AirCastingStyling in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -733,6 +737,7 @@
 				DDF62600269C779800F23489 /* UIApplication+AppInfo.swift.swift */,
 				DD3C99F326EA280800B42A46 /* TimeConversion.swift */,
 				DDD1F9B02705852400D8E87F /* DataFormatters.swift */,
+				DDB44C242704AF830027176E /* AveragingService.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1463,6 +1468,7 @@
 				AC6D567B25AC540D00D221BA /* Charts */,
 				AC787D74267B41990034B222 /* AirCastingStyling */,
 				ACF600BD2678D7F4005DD97C /* SwiftSimplify */,
+				AC5226C2270C50520048A585 /* Algorithms */,
 			);
 			productName = AirCasting;
 			productReference = AC7EB37225A6FB3A00A7F2AF /* AirCasting.app */;
@@ -1498,6 +1504,7 @@
 			packageReferences = (
 				AC6D567A25AC540D00D221BA /* XCRemoteSwiftPackageReference "Charts" */,
 				ACF600BC2678D7F4005DD97C /* XCRemoteSwiftPackageReference "SwiftSimplify" */,
+				AC5226C1270C50520048A585 /* XCRemoteSwiftPackageReference "swift-algorithms" */,
 			);
 			productRefGroup = AC7EB37325A6FB3A00A7F2AF /* Products */;
 			projectDirPath = "";
@@ -1728,6 +1735,7 @@
 				ACD32A4F2600A8DD00818946 /* SettingsView.swift in Sources */,
 				4F8CDBD4265F8EE000976B25 /* SessionStorage.swift in Sources */,
 				B376DD23268091B80083FD2F /* BodyEncodingError.swift in Sources */,
+				DDB44C252704AF830027176E /* AveragingService.swift in Sources */,
 				AC9F526C2652A360003CF61F /* DashboardView.swift in Sources */,
 				AC3203CB25CA991C00A68520 /* TurnOnBluetoothView.swift in Sources */,
 				DD430B0C26710E0600F1BF2E /* PrivacyOnboarding.swift in Sources */,
@@ -2167,6 +2175,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		AC5226C1270C50520048A585 /* XCRemoteSwiftPackageReference "swift-algorithms" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-algorithms.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
 		AC6D567A25AC540D00D221BA /* XCRemoteSwiftPackageReference "Charts" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/danielgindi/Charts";
@@ -2186,6 +2202,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		AC5226C2270C50520048A585 /* Algorithms */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AC5226C1270C50520048A585 /* XCRemoteSwiftPackageReference "swift-algorithms" */;
+			productName = Algorithms;
+		};
 		AC6D567B25AC540D00D221BA /* Charts */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = AC6D567A25AC540D00D221BA /* XCRemoteSwiftPackageReference "Charts" */;

--- a/AirCasting.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AirCasting.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,6 +11,24 @@
         }
       },
       {
+        "package": "swift-algorithms",
+        "repositoryURL": "https://github.com/apple/swift-algorithms.git",
+        "state": {
+          "branch": null,
+          "revision": "b14b7f4c528c942f121c8b860b9410b2bf57825e",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "package": "swift-numerics",
+        "repositoryURL": "https://github.com/apple/swift-numerics",
+        "state": {
+          "branch": null,
+          "revision": "0a23770641f65a4de61daf5425a37ae32a3fd00d",
+          "version": "1.0.1"
+        }
+      },
+      {
         "package": "SwiftSimplify",
         "repositoryURL": "https://github.com/smialko/SwiftSimplify",
         "state": {

--- a/AirCasting/CoreData/AirCasting.xcdatamodeld/AirCasting.xcdatamodel/contents
+++ b/AirCasting/CoreData/AirCasting.xcdatamodeld/AirCasting.xcdatamodel/contents
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="18154" systemVersion="20D91" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19206" systemVersion="20G165" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="MeasurementEntity" representedClassName="MeasurementEntity" syncable="YES">
+        <attribute name="averagingWindow" optional="YES" attributeType="Integer 64" defaultValueString="1" usesScalarValueType="YES"/>
         <attribute name="id" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="latitude" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="longitude" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
@@ -55,7 +56,7 @@
         <relationship name="measurementStreams" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="MeasurementStreamEntity" inverseName="session" inverseEntity="MeasurementStreamEntity"/>
     </entity>
     <elements>
-        <element name="MeasurementEntity" positionX="-63" positionY="-18" width="128" height="119"/>
+        <element name="MeasurementEntity" positionX="-63" positionY="-18" width="128" height="134"/>
         <element name="MeasurementStreamEntity" positionX="-63.7001953125" positionY="128.3192749023438" width="128" height="254"/>
         <element name="SensorThreshold" positionX="388.8433837890625" positionY="56.29141235351562" width="128" height="133"/>
         <element name="SessionEntity" positionX="160" positionY="192" width="128" height="314"/>

--- a/AirCasting/CoreData/MeasurementEntity.swift
+++ b/AirCasting/CoreData/MeasurementEntity.swift
@@ -13,6 +13,8 @@ public class MeasurementEntity: NSManagedObject, Identifiable {
         return NSFetchRequest<MeasurementEntity>(entityName: "MeasurementEntity")
     }
 
+    @NSManaged public var averagingWindow: Int
+    
     public var id: MeasurementID? {
         get { value(forKey: "id") as? MeasurementID }
         set { setValue(newValue, forKey: "id")}
@@ -21,6 +23,7 @@ public class MeasurementEntity: NSManagedObject, Identifiable {
     @NSManaged public var time: Date!
     @NSManaged public var value: Double
     @NSManaged public var measurementStream: MeasurementStreamEntity!
+
 
     public var location: CLLocationCoordinate2D? {
         get {

--- a/AirCasting/CoreData/MeasurementStreamStorage.swift
+++ b/AirCasting/CoreData/MeasurementStreamStorage.swift
@@ -120,7 +120,7 @@ final class HiddenCoreDataMeasurementStreamStorage: MeasurementStreamStorageCont
         return stream?.localID
     }
     
-    func getExistingSessionWith(_ sessionUUID: SessionUUID) throws -> SessionEntity? {
+    func getExistingSession(with sessionUUID: SessionUUID) throws -> SessionEntity? {
         let session = try context.existingSession(uuid: sessionUUID)
         return session
     }

--- a/AirCasting/CoreData/PersistenceController.swift
+++ b/AirCasting/CoreData/PersistenceController.swift
@@ -60,6 +60,7 @@ class PersistenceController: ObservableObject {
     func editContext() -> NSManagedObjectContext {
         let ctx = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
         ctx.parent = sourceOfTruthContext
+        ctx.automaticallyMergesChangesFromParent = true
         return ctx
     }
     

--- a/AirCasting/CreateSessionViews/ConfirmCreatingSessionView.swift
+++ b/AirCasting/CreateSessionViews/ConfirmCreatingSessionView.swift
@@ -127,6 +127,7 @@ extension ConfirmCreatingSessionView {
                         selectedSection.selectedSection = SelectedSection.following
                     }
                     tabSelection.selection = TabBarSelection.Tab.dashboard
+                    
                 case .failure(let error):
                     self.error = error as NSError
                     Log.warning("Failed to create session \(error)")

--- a/AirCasting/Dashboard/DashboardView.swift
+++ b/AirCasting/Dashboard/DashboardView.swift
@@ -13,6 +13,8 @@ struct DashboardView: View {
     @StateObject var coreDataHook: CoreDataHook
     @FetchRequest<SensorThreshold>(sortDescriptors: [.init(key: "sensorName", ascending: true)]) var thresholds
     @EnvironmentObject var selectedSection: SelectSection
+    @EnvironmentObject var averaging: AveragingService
+    
     let measurementStreamStorage: MeasurementStreamStorage
     let sessionStoppableFactory: SessionStoppableFactory
 

--- a/AirCasting/Utils/AveragingService.swift
+++ b/AirCasting/Utils/AveragingService.swift
@@ -78,7 +78,11 @@ final class AveragingService: NSObject, ObservableObject {
             
             let frc = storage.observerFor(request: request)
             
-            try! frc.performFetch()
+            do {
+                try frc.performFetch()
+            } catch {
+                Log.info("Couldn't perform a fetch and add observer")
+            }
             frc.delegate = self
             self?.fetchedResultsController = frc
         }
@@ -88,7 +92,7 @@ final class AveragingService: NSObject, ObservableObject {
         if let uuid = sessionEntity.uuid {
             measurementStreamStorage.accessStorage { storage in
                 
-                let session = try? storage.getExistingSessionWith(uuid)
+                let session = try? storage.getExistingSession(with: uuid)
                 
                 session?.allStreams?.forEach { stream in
                     var averagedMeasurements: [MeasurementEntity] = (stream.allMeasurements ?? []).filter {
@@ -133,7 +137,7 @@ final class AveragingService: NSObject, ObservableObject {
             .first()
             .sink { [weak self] _ in
                 self?.measurementStreamStorage.accessStorage { storage in
-                    guard let session = try? storage.getExistingSessionWith(uuid) else { return }
+                    guard let session = try? storage.getExistingSession(with: uuid) else { return }
                     self?.startPeriodicAveraging(session: session)
                 }
             }

--- a/AirCasting/Utils/AveragingService.swift
+++ b/AirCasting/Utils/AveragingService.swift
@@ -1,0 +1,173 @@
+// Created by Lunar on 29/09/2021.
+//
+
+import Foundation
+import Combine
+import CoreData
+import Algorithms
+
+/**
+  * Averaging for long mobile sessions
+  *
+  * General rules:
+  * - for streams containing >2 hrs but <9 hrs of data apply a 5-second avg. time interval.
+  * - for streams containing >9 hrs of data apply a 60-second avg. time interval
+  *
+  * Use case:
+  * - the mobile active session reaches a duration of 2 hours and 5 seconds.
+  * - at 2 hours and 5 seconds, the first 5-second average measurement is plotted on the map and graph.
+  * - all of the data from the prior 2 hours is transformed into 5-second averages and the map and graph and stats are updated accordingly.
+  *
+  * Notes:
+  * - averages should be attached to the middle value geocoordinates and timestamps,
+  * i.e. if its a 5-second avg spanning the time frame 10:00:00 to 10:00:05,
+  * the avg value gets pegged to the geocoordinates and timestamp from 10:00:03.
+  * - thresholds are calculated based on ellapsed time of session, not based on actual measurements records
+  * (pauses in sessions are not taken into account)
+  * - if there are any final, unaveraged measurements on 2h+ or 9h+ session which would not fall into full averaging window
+  * (5s or 60s) they should be deleted
+  * - on threshold crossing (at 2h and at 9h into session) we also trim measurements that not fit into given window size
+  *
+  **/
+
+//TODO:
+// 5. get proper averaging window (for threshold)
+
+struct AvgMeasurement {
+    let window: AveragingWindow = .zeroWindow
+    let treshold: TimeThreshold
+}
+
+enum AveragingWindow: Int {
+    case zeroWindow = 1
+    case firstThresholdWindow = 5
+    case secondThresholdWindow = 60
+}
+
+enum TimeThreshold: Int {
+    // Two hours: 60 * 60 * 2 = 7200
+    case firstThreshold = 7200
+    // Nine hours: 60 * 60 * 9 = 32400
+    case secondThreshold = 32400
+}
+
+final class AveragingService: NSObject, ObservableObject {
+    // TODO:
+    // 1. calculate average
+    // 2. remove unaveraged measurements
+    // 3. mark measurements as averaged
+    // 4. setup timer for new session
+    // 5. perform averaging of previous measurements after crossing threshold
+    // 5. get proper averaging window (for threshold)
+    
+    private var sessionEntity: SessionEntity?
+    private let measurementStreamStorage: MeasurementStreamStorage
+    private var timers: [SessionUUID : AnyCancellable] = [:]
+    private var fetchedResultsController: NSFetchedResultsController<SessionEntity>?
+    
+    init(measurementStreamStorage: MeasurementStreamStorage) {
+        self.measurementStreamStorage = measurementStreamStorage
+        super.init()
+        
+        measurementStreamStorage.accessStorage { [weak self] storage in
+            let request: NSFetchRequest<SessionEntity> = SessionEntity.fetchRequest()
+            request.predicate = NSPredicate(format: "type == %@ AND status == %i",
+                                            SessionType.mobile.rawValue,
+                                            SessionStatus.RECORDING.rawValue)
+            request.sortDescriptors = [NSSortDescriptor(key: "type", ascending: true)]
+            
+            let frc = storage.observerFor(request: request)
+            
+            try! frc.performFetch()
+            frc.delegate = self
+            self?.fetchedResultsController = frc
+        }
+    }
+    
+    private func perform(sessionEntity: SessionEntity, averagingWindow: AveragingWindow) {
+        if let uuid = sessionEntity.uuid {
+            measurementStreamStorage.accessStorage { storage in
+                
+                let session = try? storage.getExistingSessionWith(uuid)
+                
+                session?.allStreams?.forEach { stream in
+                    var averagedMeasurements: [MeasurementEntity] = (stream.allMeasurements ?? []).filter {
+                        $0.averagingWindow != AveragingWindow.zeroWindow.rawValue
+                    }
+                    let unaveragedMeasurements: [MeasurementEntity] = (stream.allMeasurements ?? []).filter {
+                        $0.averagingWindow == AveragingWindow.zeroWindow.rawValue
+                    }
+                    
+                    unaveragedMeasurements.chunks(ofCount: averagingWindow.rawValue).forEach( { measuremensInChunk in
+                        if (measuremensInChunk.count == averagingWindow.rawValue) {
+                            /// https://github.com/apple/swift-algorithms/blob/main/Guides/Chunked.md
+                            /// For integer types, any remainder of the division is discarded so we need to add 1 to elementsInChunk/2 to get the middle value.
+                            let middleIndex = measuremensInChunk.index(measuremensInChunk.startIndex, offsetBy: (averagingWindow.rawValue/2 + 1))
+                            let middleMeasurement = measuremensInChunk[middleIndex]
+                            middleMeasurement.value = self.calculateAvg(from: measuremensInChunk)
+                            middleMeasurement.averagingWindow = averagingWindow.rawValue
+                            averagedMeasurements.append(middleMeasurement)
+                        }
+                    })
+                    do {
+                        if !averagedMeasurements.isEmpty {
+                            try storage.updateMeasurements(stream: stream, newMeasurements: NSOrderedSet(array: averagedMeasurements))
+                        }
+                    } catch {
+                        Log.info("Couldn't update Measurements for stream \(stream)")
+                    }
+                }
+            }
+        }
+    }
+    
+    private func calculateAvg(from values: ChunksOfCountCollection<[MeasurementEntity]>.Element) -> Double {
+       return values.map({ $0.value }).reduce(0.0, +) / Double(values.count)
+    }
+    
+    private func scheduleAveraging(session: SessionEntity) {
+        let uuid = session.uuid!
+        
+        let timer = Timer.publish(every: TimeInterval(TimeThreshold.firstThreshold.rawValue), on: .main, in: .common)
+            .autoconnect()
+            .first()
+            .sink { [weak self] _ in
+                self?.measurementStreamStorage.accessStorage { storage in
+                    guard let session = try? storage.getExistingSessionWith(uuid) else { return }
+                    self?.startPeriodicAveraging(session: session)
+                }
+            }
+        timers[uuid] = timer
+    }
+    
+    private func startPeriodicAveraging(session: SessionEntity) {
+        guard let context = session.managedObjectContext,
+              let uuid = session.uuid else { return }
+
+        let timer = Timer.publish(every: 5.0, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] _ in
+                context.perform {
+                    guard let session = try? context.existingSession(uuid: uuid) else { return }
+                    self?.perform(sessionEntity: session, averagingWindow: .firstThresholdWindow)
+                }
+            }
+        timers[session.uuid] = timer
+    }
+}
+
+extension AveragingService: NSFetchedResultsControllerDelegate {
+    
+    func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) {
+        guard let session = anObject as? SessionEntity else { return }
+        
+        switch type {
+        case .insert:
+            scheduleAveraging(session: session)
+        case .delete:
+            timers[session.uuid] = nil
+        default: break
+        }
+    }
+    
+}


### PR DESCRIPTION
1. Added observer to the database which checks if there's a mobile recording session
2. After the session is added/"removed" this method is automatically called` func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?)` and either start the timer for this session or stops it
3. There's a timer that after 2 hours of recording calls a method that perform averaging every 5s
4. Averaging method wasn't built by me, I just refactored it a bit :) 