### PR TITLE
fix measurement time to proper one 

### DIFF
--- a/AirCasting/CoreData/MeasurementStreamStorage.swift
+++ b/AirCasting/CoreData/MeasurementStreamStorage.swift
@@ -24,8 +24,8 @@ protocol MeasurementStreamStorageContextUpdate {
 }
 
 extension HiddenCoreDataMeasurementStreamStorage {
-    func addMeasurementValue(_ value: Double, at location: CLLocationCoordinate2D? = nil, toStreamWithID id: MeasurementStreamLocalID) throws {
-        try addMeasurement(Measurement(time: Date(), value: value, location: location), toStreamWithID: id)
+    func addMeasurementValue(_ value: Double, at location: CLLocationCoordinate2D? = nil, toStreamWithID id: MeasurementStreamLocalID, on time: Date? = Date()) throws {
+        try addMeasurement(Measurement(time: time!, value: value, location: location), toStreamWithID: id)
     }
 }
 

--- a/AirCasting/SessionViews/SessionCartViewModel/DefaultSyncingMeasurementsViewModel.swift
+++ b/AirCasting/SessionViews/SessionCartViewModel/DefaultSyncingMeasurementsViewModel.swift
@@ -62,7 +62,8 @@ final class DefaultSyncingMeasurementsViewModel: SyncingMeasurementsViewModel {
                                     return }
                                 try storage.addMeasurementValue(measurement.value,
                                                                 at:  location,
-                                                                toStreamWithID: streamID)
+                                                                toStreamWithID: streamID,
+                                                                on: measurement.time)
                             } catch {
                                 Log.info("\(error)")
                             }


### PR DESCRIPTION
For now, there was a difference in the graph between android and iOS. The reason was the measurement time was equal always to = Date() and not the measurement. time as it should be. Now the graph is looking cool I think

https://trello.com/c/2VEszn7M/329-mobile-dormant-graph-inaccurate-missing-data