### PR TITLE
Fix - midnight lines on graph

### DIFF
--- a/AirCasting/Graph/Graph.swift
+++ b/AirCasting/Graph/Graph.swift
@@ -79,22 +79,25 @@ struct Graph: UIViewRepresentable {
     }
     
     func getMidnightsPoints(startingDate: Date) -> [Double] {
-        let now = Date()
+        let day = Date()
+        // [SMALL HACK] - By adding a day to the current Date we are ensuring
+        // that session which is currently recording will be able to show midnight line
+        let now = Calendar.current.date(byAdding: .day, value: 1, to: day)!
         var midnight = Calendar.current.date(bySettingHour: 0, minute: 0, second: 0, of: now)!
         let components = Calendar.current.dateComponents([.hour, .minute, .second], from: midnight)
         let firstMeasurementDate = startingDate
         var midnightPoints: [Double] = []
         
         while (midnight > firstMeasurementDate) {
-            let previus = Calendar.current.nextDate(after: midnight,
+            let previous = Calendar.current.nextDate(after: midnight,
                                                     matching: components,
                                                     matchingPolicy: Calendar.MatchingPolicy.previousTimePreservingSmallerComponents,
                                                     repeatedTimePolicy: Calendar.RepeatedTimePolicy.first,
                                                     direction: .backward)
-            if let midnightPoint = previus?.timeIntervalSince1970 {
+            if let midnightPoint = previous?.timeIntervalSince1970 {
                 midnightPoints.append(midnightPoint)
             }
-            midnight = previus!
+            midnight = previous!
         }
         return midnightPoints
     }


### PR DESCRIPTION
In this ticket, I've added a day to the current day when looking for midnight points. It is a small hack that will allow us to consider each day when looking for midnight. It is needed especially on the existing, recording sessions.

https://trello.com/c/qHtJtfC6/273-all-tabs-graph-show-midnight-lines