### PR TITLE
Start timers for chart for new sessions and refresh chart on appear

### DIFF
--- a/AirCasting/SessionViews/ChartViewModel.swift
+++ b/AirCasting/SessionViews/ChartViewModel.swift
@@ -34,7 +34,7 @@ final class ChartViewModel: ObservableObject {
         self.session = session
         self.chartStartTime = session.endTime
         self.chartEndTime = session.endTime
-        if session.isActive || session.isFollowed {
+        if session.isActive || session.isFollowed || session.status == .NEW {
             startTimers(session)
         }
     }
@@ -51,6 +51,10 @@ final class ChartViewModel: ObservableObject {
         mainTimer = Timer.scheduledTimer(withTimeInterval: timeUnit, repeats: true) { [weak self] timer in
             self?.generateEntries()
         }
+    }
+    
+    func refreshChart() {
+        generateEntries()
     }
     
     private func generateEntries() {
@@ -70,7 +74,6 @@ final class ChartViewModel: ObservableObject {
         var intervalStart = intervalEnd - timeUnit
         
         var entries = [ChartDataEntry]()
-        
         for i in (0..<numberOfEntries).reversed() {
             if (intervalStart < stream!.session.startTime!.roundedDownToSecond) { break }
             let average = averagedValue(intervalStart, intervalEnd)

--- a/AirCasting/SessionViews/SessionCartView.swift
+++ b/AirCasting/SessionViews/SessionCartView.swift
@@ -225,6 +225,9 @@ private extension SessionCartView {
                     }.foregroundColor(.aircastingGray)
                     .font(Font.muli(size: 13, weight: .semibold))
                 }
+                .onAppear {
+                    chartViewModel.refreshChart()
+                }
             }
         }
     }


### PR DESCRIPTION
This PR fixes issue with:
- chart not appearing for followed session (only for the first followed session) until the stream was selected
- chart not refreshing for mobile AB sessions