### PR TITLE
reduce the size between sections

### DIFF
--- a/AirCasting/Dashboard/AirSectionPickerView.swift
+++ b/AirCasting/Dashboard/AirSectionPickerView.swift
@@ -62,7 +62,7 @@ struct PickerButtonStyle: ButtonStyle {
             .font(isSelected ? Font.muli(size: 16, weight: .bold) : Font.muli(size: 16, weight: .regular))
             .frame(maxHeight: 30)
             .background(Color.white)
-            .padding(.horizontal)
+            .padding(.horizontal, 10)
             .padding(.top)
     }
 }

--- a/AirCasting/Dashboard/DashboardView.swift
+++ b/AirCasting/Dashboard/DashboardView.swift
@@ -38,6 +38,7 @@ struct DashboardView: View {
             // Bug report was filled with Apple
             PreventCollapseView()
             AirSectionPickerView(selection: self.$selectedSection.selectedSection)
+                .padding(.leading, 8)
 
             if sessions.isEmpty {
                 if selectedSection.selectedSection == .mobileActive || selectedSection.selectedSection == .mobileDormant {


### PR DESCRIPTION
https://trello.com/c/4RrL5LWV/333-dashboard-all-tabs-reduce-vertical-space-between-cards-so-it-matches-the-android-app

The main idea for this is to reduce the size between picker buttons and match the app closer to android 