### PR TITLE
Stats container fix

### DIFF
--- a/AirCasting/Graph/StatisticsContainer/Adapters/MapStatsDataSource.swift
+++ b/AirCasting/Graph/StatisticsContainer/Adapters/MapStatsDataSource.swift
@@ -23,9 +23,12 @@ class MapStatsDataSource: MeasurementsStatisticsDataSource, ObservableObject {
     }
     
     var visibleMeasurements: [MeasurementStatistics.Measurement] {
-        let visible = visiblePathPoints.map { MeasurementStatistics.Measurement(measurementTime: $0.measurementTime, value: $0.measurement) }
-        // In case there are no visible data items let's fallback to showing data for all of them.
-        guard visible.count > 0 else { return allMeasurements }
-        return visible
+    #warning("TODO: Implement calculating stats only for visible path points")
+        // The implementation for visible points on map doesn't work as it should. That's why I'm commenting it out and we have  to fix it in another PR
+//        let visible = visiblePathPoints.map { MeasurementStatistics.Measurement(measurementTime: $0.measurementTime, value: $0.measurement) }
+//        // In case there are no visible data items let's fallback to showing data for all of them.
+//        guard visible.count > 0 else { return allMeasurements }
+//        return visible
+        return stream?.allMeasurements?.getStatistics() ?? []
     }
 }

--- a/AirCasting/Map/AirMapView.swift
+++ b/AirCasting/Map/AirMapView.swift
@@ -16,7 +16,7 @@ struct AirMapView: View {
     
     var thresholds: [SensorThreshold]
     @StateObject var statsContainerViewModel: StatisticsContainerViewModel
-    @StateObject var mapStatsDataSource: MapStatsDataSource
+    let mapStatsDataSource: MapStatsDataSource
     let session: SessionEntity
     @Binding var showLoadingIndicator: Bool
 

--- a/AirCasting/Map/AirMapView.swift
+++ b/AirCasting/Map/AirMapView.swift
@@ -16,8 +16,8 @@ struct AirMapView: View {
     
     var thresholds: [SensorThreshold]
     @StateObject var statsContainerViewModel: StatisticsContainerViewModel
-    let mapStatsDataSource: MapStatsDataSource
-    let session: SessionEntity
+    @StateObject var mapStatsDataSource: MapStatsDataSource
+    @ObservedObject var session: SessionEntity
     @Binding var showLoadingIndicator: Bool
 
     @Binding var selectedStream: MeasurementStreamEntity?

--- a/AirCasting/Map/AirMapView.swift
+++ b/AirCasting/Map/AirMapView.swift
@@ -60,6 +60,7 @@ struct AirMapView: View {
                     ZStack(alignment: .topLeading) {
                         GoogleMapView(pathPoints: pathPoints,
                                       threshold: threshold, placePickerDismissed: Binding.constant(false))
+                        #warning("TODO: Implement calculating stats only for visible path points")
                         // This doesn't work properly and it needs to be fixed, so I'm commenting it out
 //                            .onPositionChange { [weak mapStatsDataSource, weak statsContainerViewModel] visiblePoints in
 //                                mapStatsDataSource?.visiblePathPoints = visiblePoints

--- a/AirCasting/Map/AirMapView.swift
+++ b/AirCasting/Map/AirMapView.swift
@@ -17,7 +17,7 @@ struct AirMapView: View {
     var thresholds: [SensorThreshold]
     @StateObject var statsContainerViewModel: StatisticsContainerViewModel
     @StateObject var mapStatsDataSource: MapStatsDataSource
-    @ObservedObject var session: SessionEntity
+    let session: SessionEntity
     @Binding var showLoadingIndicator: Bool
 
     @Binding var selectedStream: MeasurementStreamEntity?
@@ -81,6 +81,11 @@ struct AirMapView: View {
                 }
             }
         }
+//        .onChange(of: selectedStream) { newStream in
+////            mapStatsDataSource.stream = newStream
+//            statsContainerViewModel.adjustForNewData()
+//            print("## Called adjusting data")
+//        }
         .onChange(of: scenePhase) { phase in
             switch phase {
             case .background, .inactive: self.presentationMode.wrappedValue.dismiss()

--- a/AirCasting/Map/AirMapView.swift
+++ b/AirCasting/Map/AirMapView.swift
@@ -62,6 +62,7 @@ struct AirMapView: View {
                                       threshold: threshold, placePickerDismissed: Binding.constant(false))
                             .onPositionChange { [weak mapStatsDataSource, weak statsContainerViewModel] visiblePoints in
                                 mapStatsDataSource?.visiblePathPoints = visiblePoints
+                                print(visiblePoints.count)
                                 statsContainerViewModel?.adjustForNewData()
                             }
                         // Statistics container shouldn't be presented in mobile dormant tab
@@ -81,11 +82,12 @@ struct AirMapView: View {
                 }
             }
         }
-//        .onChange(of: selectedStream) { newStream in
-////            mapStatsDataSource.stream = newStream
-//            statsContainerViewModel.adjustForNewData()
-//            print("## Called adjusting data")
-//        }
+        .onChange(of: selectedStream) { newStream in
+//            mapStatsDataSource.stream = newStream
+            mapStatsDataSource.visiblePathPoints = pathPoints
+            statsContainerViewModel.adjustForNewData()
+            print("## Called adjusting data")
+        }
         .onChange(of: scenePhase) { phase in
             switch phase {
             case .background, .inactive: self.presentationMode.wrappedValue.dismiss()

--- a/AirCasting/Map/AirMapView.swift
+++ b/AirCasting/Map/AirMapView.swift
@@ -60,11 +60,11 @@ struct AirMapView: View {
                     ZStack(alignment: .topLeading) {
                         GoogleMapView(pathPoints: pathPoints,
                                       threshold: threshold, placePickerDismissed: Binding.constant(false))
-                            .onPositionChange { [weak mapStatsDataSource, weak statsContainerViewModel] visiblePoints in
-                                mapStatsDataSource?.visiblePathPoints = visiblePoints
-                                print(visiblePoints.count)
-                                statsContainerViewModel?.adjustForNewData()
-                            }
+                        // This doesn't work properly and it needs to be fixed, so I'm commenting it out
+//                            .onPositionChange { [weak mapStatsDataSource, weak statsContainerViewModel] visiblePoints in
+//                                mapStatsDataSource?.visiblePathPoints = visiblePoints
+//                                statsContainerViewModel?.adjustForNewData()
+//                            }
                         // Statistics container shouldn't be presented in mobile dormant tab
                         if !(session.type == .mobile && session.isActive == false) {
                             StatisticsContainerView(statsContainerViewModel: statsContainerViewModel,
@@ -83,10 +83,8 @@ struct AirMapView: View {
             }
         }
         .onChange(of: selectedStream) { newStream in
-//            mapStatsDataSource.stream = newStream
             mapStatsDataSource.visiblePathPoints = pathPoints
             statsContainerViewModel.adjustForNewData()
-            print("## Called adjusting data")
         }
         .onChange(of: scenePhase) { phase in
             switch phase {

--- a/AirCasting/Map/AirMapView.swift
+++ b/AirCasting/Map/AirMapView.swift
@@ -16,7 +16,7 @@ struct AirMapView: View {
     
     var thresholds: [SensorThreshold]
     @StateObject var statsContainerViewModel: StatisticsContainerViewModel
-    @StateObject var mapStatsDataSource: MapStatsDataSource
+//    @StateObject var mapStatsDataSource: MapStatsDataSource
     @ObservedObject var session: SessionEntity
     @Binding var showLoadingIndicator: Bool
 
@@ -83,10 +83,10 @@ struct AirMapView: View {
                 }
             }
         }
-        .onChange(of: selectedStream) { newStream in
-            mapStatsDataSource.visiblePathPoints = pathPoints
-            statsContainerViewModel.adjustForNewData()
-        }
+//        .onChange(of: selectedStream) { newStream in
+//            mapStatsDataSource.visiblePathPoints = pathPoints
+//            statsContainerViewModel.adjustForNewData()
+//        }
         .onChange(of: scenePhase) { phase in
             switch phase {
             case .background, .inactive: self.presentationMode.wrappedValue.dismiss()
@@ -113,7 +113,7 @@ struct Map_Previews: PreviewProvider {
     static var previews: some View {
         AirMapView(thresholds: [SensorThreshold.mock],
                    statsContainerViewModel: StatisticsContainerViewModel(statsInput: MeasurementsStatisticsInputMock()),
-                   mapStatsDataSource: MapStatsDataSource(),
+//                   mapStatsDataSource: MapStatsDataSource(),
                    session: .mock,
                    showLoadingIndicator: .constant(true),
                    selectedStream: .constant(nil),

--- a/AirCasting/Map/GoogleMapView.swift
+++ b/AirCasting/Map/GoogleMapView.swift
@@ -48,6 +48,7 @@ struct GoogleMapView: UIViewRepresentable {
     /// - Parameter action: an action block that takes an array of currently visible `PathPoint`s.
     func onPositionChange(action: @escaping (_ visiblePoints: [PathPoint]) -> ()) -> Self {
         var newSelf = self
+        print(pathPoints.last?.measurement)
         newSelf.onPositionChange = action
         return newSelf
     }
@@ -179,6 +180,7 @@ struct GoogleMapView: UIViewRepresentable {
             let visibleRegion = mapView.projection.visibleRegion()
             let bounds = GMSCoordinateBounds(region: visibleRegion)
             let visiblePathPoints = parent.pathPoints.filter { bounds.contains($0.location) }
+            print("In map: \(visiblePathPoints.last?.measurement)")
             parent.onPositionChange?(visiblePathPoints)
         }
 

--- a/AirCasting/Map/GoogleMapView.swift
+++ b/AirCasting/Map/GoogleMapView.swift
@@ -48,7 +48,6 @@ struct GoogleMapView: UIViewRepresentable {
     /// - Parameter action: an action block that takes an array of currently visible `PathPoint`s.
     func onPositionChange(action: @escaping (_ visiblePoints: [PathPoint]) -> ()) -> Self {
         var newSelf = self
-        print(pathPoints.last?.measurement)
         newSelf.onPositionChange = action
         return newSelf
     }
@@ -180,7 +179,6 @@ struct GoogleMapView: UIViewRepresentable {
             let visibleRegion = mapView.projection.visibleRegion()
             let bounds = GMSCoordinateBounds(region: visibleRegion)
             let visiblePathPoints = parent.pathPoints.filter { bounds.contains($0.location) }
-            print("In map: \(visiblePathPoints.last?.measurement)")
             parent.onPositionChange?(visiblePathPoints)
         }
 

--- a/AirCasting/SessionViews/SessionCartView.swift
+++ b/AirCasting/SessionViews/SessionCartView.swift
@@ -76,7 +76,7 @@ struct SessionCartView: View {
             .fullScreenCover(isPresented: $isMapButtonActive) {
                 AirMapView(thresholds: thresholds,
                            statsContainerViewModel: mapStatsViewModel,
-                           mapStatsDataSource: mapStatsDataSource,
+//                           mapStatsDataSource: mapStatsDataSource,
                            session: session,
                            showLoadingIndicator: $showLoadingIndicator,
                            selectedStream: $selectedStream,
@@ -99,7 +99,7 @@ struct SessionCartView: View {
             .fullScreenCover(isPresented: $isMapButtonActive) {
                 AirMapView(thresholds: thresholds,
                            statsContainerViewModel: mapStatsViewModel,
-                           mapStatsDataSource: mapStatsDataSource,
+//                           mapStatsDataSource: mapStatsDataSource,
                            session: session,
                            showLoadingIndicator: $showLoadingIndicator,
                            selectedStream: $selectedStream,


### PR DESCRIPTION
This removes (or actually comments out, cause it might be useful in the future) functionality for showing statistics in zoomed area on map only. Instead we are always showing statistics for all of the measurements for selected stream