### PR TITLE
stay on map

### DIFF
--- a/AirCasting/CreateSessionViews/ChooseCustomLocationView.swift
+++ b/AirCasting/CreateSessionViews/ChooseCustomLocationView.swift
@@ -40,7 +40,7 @@ struct ChooseCustomLocationView: View {
     }
 
     var mapGoogle: some View {
-        GoogleMapView(pathPoints: [], placePickerDismissed: $placePickerPresented)
+        GoogleMapView(pathPoints: [], placePickerDismissed: $placePickerPresented, isUserInteracting: Binding.constant(true))
     }
 
     var dot: some View {

--- a/AirCasting/CreateSessionViews/ConfirmCreatingSessionView.swift
+++ b/AirCasting/CreateSessionViews/ConfirmCreatingSessionView.swift
@@ -90,9 +90,9 @@ struct ConfirmCreatingSessionView: View {
                 .lineSpacing(9.0)
                 ZStack {
                     if sessionContext.sessionType == .mobile {
-                        GoogleMapView(pathPoints: [], isMyLocationEnabled: true, placePickerDismissed: Binding.constant(false))
+                        GoogleMapView(pathPoints: [], isMyLocationEnabled: true, placePickerDismissed: Binding.constant(false), isUserInteracting: Binding.constant(true))
                     } else if !(sessionContext.isIndoor ?? false) {
-                        GoogleMapView(pathPoints: [], placePickerDismissed: Binding.constant(false))
+                        GoogleMapView(pathPoints: [], placePickerDismissed: Binding.constant(false), isUserInteracting: Binding.constant(true))
                             .disabled(true)
                         // It needs to be disabled to prevent user interaction (swiping map) because it is only conformation screen
                         dot

--- a/AirCasting/Map/AirMapView.swift
+++ b/AirCasting/Map/AirMapView.swift
@@ -12,14 +12,13 @@ import CoreData
 
 struct AirMapView: View {
     @Environment(\.scenePhase) var scenePhase
-    @Environment(\.presentationMode) var presentationMode
     
     var thresholds: [SensorThreshold]
     @StateObject var statsContainerViewModel: StatisticsContainerViewModel
 //    @StateObject var mapStatsDataSource: MapStatsDataSource
     @ObservedObject var session: SessionEntity
     @Binding var showLoadingIndicator: Bool
-
+    @State var isUserInteracting = true
     @Binding var selectedStream: MeasurementStreamEntity?
     let sessionStoppableFactory: SessionStoppableFactory
     let measurementStreamStorage: MeasurementStreamStorage
@@ -58,7 +57,8 @@ struct AirMapView: View {
                     ZStack(alignment: .topLeading) {
                         GoogleMapView(pathPoints: pathPoints,
                                       threshold: threshold,
-                                      placePickerDismissed: Binding.constant(false))
+                                      placePickerDismissed: Binding.constant(false),
+                                      isUserInteracting: $isUserInteracting)
                         #warning("TODO: Implement calculating stats only for visible path points")
                         // This doesn't work properly and it needs to be fixed, so I'm commenting it out
 //                            .onPositionChange { [weak mapStatsDataSource, weak statsContainerViewModel] visiblePoints in
@@ -89,8 +89,8 @@ struct AirMapView: View {
 //        }
         .onChange(of: scenePhase) { phase in
             switch phase {
-            case .background, .inactive: self.presentationMode.wrappedValue.dismiss()
-            case .active: break
+            case .background, .inactive: isUserInteracting = false
+            case .active: isUserInteracting = true
             @unknown default: fatalError()
             }
         }

--- a/AirCasting/Map/GoogleMapView.swift
+++ b/AirCasting/Map/GoogleMapView.swift
@@ -58,7 +58,7 @@ struct GoogleMapView: UIViewRepresentable {
     }
     
     func updateUIView(_ uiView: GMSMapView, context: Context) {
-        if isUserInteracting {
+        guard isUserInteracting else { return }
             let thresholdWitness = ThresholdWitness(sensorThreshold: self.threshold)
             if pathPoints != context.coordinator.currentlyDisplayedPathPoints ||
                 thresholdWitness != context.coordinator.currentThreshold {
@@ -77,7 +77,6 @@ struct GoogleMapView: UIViewRepresentable {
                         uiView.animate(toZoom: 16)
                     }
                 }
-            }
         }
     
     var cameraUpdate: GMSCameraUpdate {


### PR DESCRIPTION
https://trello.com/c/31DSosIn/397-mobile-active-map-stay-on-map

I know that this code implemented with .scenePhase was there for a reason, but do we really need it still? We have UI suspending feature that works as user locks the phone or put app in the background. I've made other solution to specifically prevent GoogleMap updates instead of going back to homescreen, but do we really need it now?