### PR TITLE
added closed range to the last color

### DIFF
--- a/AirCasting/Extensions/SensorThreshold.swift
+++ b/AirCasting/Extensions/SensorThreshold.swift
@@ -35,7 +35,7 @@ extension SensorThreshold {
             return .aircastingYellow
         case thresholdMedium..<thresholdHigh:
             return .aircastingOrange
-        case thresholdHigh..<thresholdVeryHigh:
+        case thresholdHigh...thresholdVeryHigh:
             return .aircastingRed
         default:
             return .aircastingGray


### PR DESCRIPTION
https://trello.com/c/Zs7NWpAs/374-mobile-active-following-stats-container-threshold-values-should-be-colored-according-to-the-hlu