### PR TITLE
Background audio interruptions problems fixed

### DIFF
--- a/AirCasting.xcodeproj/project.pbxproj
+++ b/AirCasting.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 		B3E26A092676DA55001A8E4C /* TestDefaultProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E26A082676DA55001A8E4C /* TestDefaultProviding.swift */; };
 		B3E26A0D2676DAD2001A8E4C /* SynchronizationTestDoubles.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E26A0C2676DAD2001A8E4C /* SynchronizationTestDoubles.swift */; };
 		B3E26A2A26780D96001A8E4C /* SynchronizationControllerTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E26A2926780D96001A8E4C /* SynchronizationControllerTestHelpers.swift */; };
+		B3EAF78F2730C161000FFF23 /* AVSessionInterruptionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3EAF78E2730C161000FFF23 /* AVSessionInterruptionHandler.swift */; };
 		B3EBB10326A05551002BD81F /* ForgotPasswordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3EBB10226A05551002BD81F /* ForgotPasswordViewModel.swift */; };
 		B3EBB10626A06CD7002BD81F /* ScheduledForgotPasswordControllerProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3EBB10526A06CD7002BD81F /* ScheduledForgotPasswordControllerProxy.swift */; };
 		B3EBB10A26A06D11002BD81F /* EmailResetPasswordService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3EBB10926A06D11002BD81F /* EmailResetPasswordService.swift */; };
@@ -482,6 +483,7 @@
 		B3E26A082676DA55001A8E4C /* TestDefaultProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDefaultProviding.swift; sourceTree = "<group>"; };
 		B3E26A0C2676DAD2001A8E4C /* SynchronizationTestDoubles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizationTestDoubles.swift; sourceTree = "<group>"; };
 		B3E26A2926780D96001A8E4C /* SynchronizationControllerTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizationControllerTestHelpers.swift; sourceTree = "<group>"; };
+		B3EAF78E2730C161000FFF23 /* AVSessionInterruptionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVSessionInterruptionHandler.swift; sourceTree = "<group>"; };
 		B3EBB10226A05551002BD81F /* ForgotPasswordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForgotPasswordViewModel.swift; sourceTree = "<group>"; };
 		B3EBB10526A06CD7002BD81F /* ScheduledForgotPasswordControllerProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledForgotPasswordControllerProxy.swift; sourceTree = "<group>"; };
 		B3EBB10926A06D11002BD81F /* EmailResetPasswordService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailResetPasswordService.swift; sourceTree = "<group>"; };
@@ -612,6 +614,7 @@
 			isa = PBXGroup;
 			children = (
 				332F521325FA38430047236D /* MicrophoneManager.swift */,
+				B3EAF78E2730C161000FFF23 /* AVSessionInterruptionHandler.swift */,
 			);
 			path = MicrophoneSession;
 			sourceTree = "<group>";
@@ -1778,6 +1781,7 @@
 				B30BAC152694AA7200AE0476 /* MeasurementsStatisticsInput.swift in Sources */,
 				DD3C99F426EA280800B42A46 /* TimeConversion.swift in Sources */,
 				B3F1447626AE0BD4006A4612 /* SessionSynchronizerErrorStream.swift in Sources */,
+				B3EAF78F2730C161000FFF23 /* AVSessionInterruptionHandler.swift in Sources */,
 				ACF7C05F260CC9FF007C24AE /* DownloadMeasurmentsService.swift in Sources */,
 				AC9F526E2652A360003CF61F /* AirSectionPickerView.swift in Sources */,
 				AC7EB37825A6FB3A00A7F2AF /* MainTabBarView.swift in Sources */,

--- a/AirCasting/MicrophoneSession/AVSessionInterruptionHandler.swift
+++ b/AirCasting/MicrophoneSession/AVSessionInterruptionHandler.swift
@@ -1,0 +1,65 @@
+// Created by Lunar on 02/11/2021.
+//
+
+import AVKit
+
+protocol AVSessionInterruptionObserver: AnyObject {
+    func onAVSessionInteruptionStart()
+    func onAVSessionInteruptionEnd(shouldResume: Bool)
+}
+
+final class AVSessionInterruptionHandler {
+    private weak var observer: AVSessionInterruptionObserver?
+    private let audioSession: AVAudioSession
+    private var paused: Bool = false
+    private let lock = NSLock()
+    
+    init(observer: AVSessionInterruptionObserver, audioSession: AVAudioSession = .sharedInstance()) {
+        self.observer = observer
+        self.audioSession = audioSession
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(handleInterruption(from:)),
+                                               name: AVAudioSession.interruptionNotification,
+                                               object: audioSession)
+    }
+    
+    func pause() {
+        lock.lock(); defer { lock.unlock() }
+        paused = true
+    }
+    
+    func resume() {
+        lock.lock(); defer { lock.unlock() }
+        paused = false
+    }
+    
+    @objc
+    private func handleInterruption(from notification: Notification) {
+        lock.lock(); defer { lock.unlock() }
+        guard !paused, let type = getInterruptionType(from: notification) else { return }
+        switch type {
+        case .began:
+            Log.verbose("audio recorder interruption began")
+            observer?.onAVSessionInteruptionStart()
+        case .ended:
+            Log.verbose("audio recorder interruption ended")
+            let shouldResume = getResumeOptions(from: notification)?.contains(.shouldResume)
+            observer?.onAVSessionInteruptionEnd(shouldResume: shouldResume ?? false)
+        default: break
+        }
+    }
+    
+    private func getInterruptionType(from notification: Notification) -> AVAudioSession.InterruptionType? {
+        guard let userInfo = notification.userInfo,
+              let typeValue = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt,
+              let type = AVAudioSession.InterruptionType(rawValue: typeValue) else {
+                  return nil
+              }
+        return type
+    }
+    
+    private func getResumeOptions(from notification: Notification) -> AVAudioSession.InterruptionOptions? {
+        guard let optionsValue = notification.userInfo?[AVAudioSessionInterruptionOptionKey] as? UInt else { return nil }
+        return AVAudioSession.InterruptionOptions(rawValue: optionsValue)
+    }
+}

--- a/AirCasting/MicrophoneSession/MicrophoneManager.swift
+++ b/AirCasting/MicrophoneSession/MicrophoneManager.swift
@@ -6,6 +6,7 @@ import Foundation
 import AVFoundation
 import CoreAudio
 import CoreLocation
+import UIKit
 
 final class MicrophoneManager: NSObject, ObservableObject {
     static private let recordSettings: [String: Any] = [
@@ -19,33 +20,37 @@ final class MicrophoneManager: NSObject, ObservableObject {
     private var measurementStreamLocalID: MeasurementStreamLocalID?
 
     //This variable is used to block recording more than one microphone session at a time
-    private(set) var isRecording = false
-    private var recorder: AVAudioRecorder!
+    private(set) var isRecording = false {
+        didSet { isRecording ? interruptionHandler.resume() : interruptionHandler.pause() }
+    }
+    private var recorder: AVAudioRecorder?
     private lazy var audioSession = AVAudioSession.sharedInstance()
     private var levelTimer: Timer?
     private(set) var session: Session?
     private lazy var locationProvider = LocationProvider()
+    private var interruptionHandler: AVSessionInterruptionHandler!
 
     init(measurementStreamStorage: MeasurementStreamStorage) {
         self.measurementStreamStorage = measurementStreamStorage
         super.init()
+        self.interruptionHandler = .init(observer: self, audioSession: audioSession)
+        do {
+            try recorder = AVAudioRecorder(url: URL(fileURLWithPath: "/dev/null", isDirectory: true), settings: MicrophoneManager.recordSettings)
+        } catch {
+            Log.error("Could not create AVAudioRecorder: \(error.localizedDescription)")
+        }
     }
 
     func startRecording(session: Session) throws {
-        if isRecording {
-            return
-        }
+        guard !isRecording, let recorder = recorder else { return }
         
         if audioSession.recordPermission != .granted {
             throw MicrophoneSessionError.permissionNotGranted
         }
         self.session = session
-
-        try audioSession.setCategory(AVAudioSession.Category.playAndRecord)
+        try setupAudioSession()
         try audioSession.setActive(true)
-        try recorder = AVAudioRecorder(url: URL(fileURLWithPath: "/dev/null", isDirectory: true), settings: MicrophoneManager.recordSettings)
         recorder.isMeteringEnabled = true
-        recorder.delegate = self
         
         createMeasurementStream(for: session) { result in
             switch result {
@@ -57,17 +62,17 @@ final class MicrophoneManager: NSObject, ObservableObject {
         }
         locationProvider.requestLocation()
         isRecording = true
-        recorder.record()
-        sampleMeasurement()
-        levelTimer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(timerTick), userInfo: nil, repeats: true)
+        if recorder.record() {
+            levelTimer = createTimer()
+            sampleMeasurement()
+        }
     }
     
     func stopRecording() throws {
+        guard isRecording, let recorder = recorder else { return }
         levelTimer?.invalidate()
         locationProvider.stopUpdatingLocation()
-        isRecording = false
-        recorder.stop()
-        recorder = nil
+        recorder.pause()
     }
 
     deinit {
@@ -81,34 +86,67 @@ final class MicrophoneManager: NSObject, ObservableObject {
     func requestRecordPermission(_ response: @escaping (Bool) -> Void) {
         audioSession.requestRecordPermission(response)
     }
+    
+    private func setupAudioSession() throws {
+        UIApplication.shared.beginReceivingRemoteControlEvents()
+        try audioSession.setCategory(AVAudioSession.Category.playAndRecord, options: [.duckOthers])
+    }
+    
+    private func createTimer() -> Timer {
+        Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(timerTick), userInfo: nil, repeats: true)
+    }
 }
 
-extension MicrophoneManager: AVAudioRecorderDelegate {
-    func audioRecorderBeginInterruption(_ recorder: AVAudioRecorder) {
-        Log.warning("audio recorder interruption began")
+extension MicrophoneManager: AVSessionInterruptionObserver {
+    func onAVSessionInteruptionStart() {
+        Log.info("audio recorder interruption began")
+        do {
+            try pauseForRecordingInterruption()
+        } catch {
+            Log.error("Failed to pause audio session: \(error.localizedDescription)")
+            // TODO: Decide on how to handle this situation
+        }
+    }
+    
+    func onAVSessionInteruptionEnd(shouldResume: Bool) {
+        Log.info("audio recorder interruption ended (should resume? \(shouldResume ? "yes." : "no.")")
+        guard shouldResume == true, let recorder = recorder else { return }
+        do {
+            try resumeInterruptedRecording(audioRecorder: recorder)
+        } catch {
+            Log.error("Failed to resume audio session: \(error.localizedDescription)")
+            // TODO: Decide on how to handle this situation
+        }
+    }
+    
+    private func pauseForRecordingInterruption() throws {
         levelTimer?.invalidate()
+        recorder?.pause()
+        try audioSession.setActive(false, options: [])
+        disconnectCurrentSession()
+    }
+    
+    private func resumeInterruptedRecording(audioRecorder: AVAudioRecorder) throws {
+        try audioSession.setActive(true, options: [])
+        guard audioRecorder.record() else { Log.warning("recording failed to resume!"); return }
+        Log.info("recording resumed.")
+        levelTimer = createTimer()
+    }
+    
+    private func disconnectCurrentSession() {
         measurementStreamStorage.accessStorage { storage in
             do {
-                try! storage.updateSessionStatus(.DISCONNECTED, for: self.session!.uuid)
+                try storage.updateSessionStatus(.DISCONNECTED, for: self.session!.uuid)
+            } catch {
+                Log.error("Couldn't disconnect session! \(error.localizedDescription)")
             }
         }
-    }
-
-    func audioRecorderEndInterruption(_ recorder: AVAudioRecorder, withOptions flags: Int) {
-        Log.info("audio recorder end interruption")
-        if !recorder.isRecording {
-            recorder.record()
-        }
-        self.levelTimer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(self.timerTick), userInfo: nil, repeats: true)
-    }
-
-    func audioRecorderEncodeErrorDidOccur(_ recorder: AVAudioRecorder, error: Error?) {
-        assertionFailure("audio recorder encode error did occur \(String(describing: error))")
     }
 }
 
 private extension MicrophoneManager {
     func sampleMeasurement() {
+        guard let recorder = recorder else { return }
         recorder.updateMeters()
         let power = recorder.averagePower(forChannel: 0)
         var decibels = Double(power + 90.0)

--- a/AirCasting/MicrophoneSession/MicrophoneManager.swift
+++ b/AirCasting/MicrophoneSession/MicrophoneManager.swift
@@ -68,10 +68,11 @@ final class MicrophoneManager: NSObject, ObservableObject {
         }
     }
     
-    func stopRecording() throws {
+    func stopRecording() {
         guard isRecording, let recorder = recorder else { return }
         levelTimer?.invalidate()
         locationProvider.stopUpdatingLocation()
+        isRecording = false
         recorder.pause()
     }
 


### PR DESCRIPTION
[Trello](https://trello.com/c/7M33g3AR/334-microphone-doesnt-resume-recording-when-other-app-was-using-a-microphone-and-then-we-came-back-to-the-app)

* `.duckOthers` option added to our audio session. This means any other AV session will be blocked by us (for example Music app won't be able to play music because of us).
* Moved `AVAudioRecorder` to a single-instance per `MicrophoneManager` instance. This is because it's not possible to create new recorders while in background. We need one and pause/resume it instead.
* Proper session activation/deactivation mechanism added with error handling (TODO)
* `AVSessionInterruptionObserver` implemented in place of the deprecated delegate we've been using.