### PR TITLE
Reconnect only for mobile active session peripheral

### DIFF
--- a/AirCasting/ABConnector/BluetoothManager.swift
+++ b/AirCasting/ABConnector/BluetoothManager.swift
@@ -123,10 +123,11 @@ extension BluetoothManager: CBCentralManagerDelegate {
     
     func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
         Log.info("Disconnected: \(String(describing: error?.localizedDescription))")
-        guard let peripheral = connectedPeripheral else { return }
+        guard mobilePeripheralSessionManager.activeSessionInProgressWith(peripheral) else { return }
         connect(to: peripheral)
         DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(10)) {
-            guard peripheral.state == .connecting else { return }
+            guard peripheral.state != .connected else { return }
+            self.cancelPeripheralConnection(for: peripheral)
             self.connectedPeripheral = nil
             self.mobilePeripheralSessionManager.finishSession(for: peripheral,
                                                                  centralManger: self.centralManager)


### PR DESCRIPTION
This fixes the leftover bug and prevents the app from reconnecting with the AirBeam when it was set to a fixed session and not active mobile session.