### PR TITLE
Wait for discovered characteristics when reconnecting with ab

### DIFF
--- a/AirCasting/ABConnector/AirBeamServices.swift
+++ b/AirCasting/ABConnector/AirBeamServices.swift
@@ -41,11 +41,12 @@ class ConnectingAirBeamServicesBluetooth: ConnectingAirBeamServices {
             Log.info("Airebeam connected successfully")
             var characteristicsHandle: Any?
             NotificationCenter.default.removeObserver(self.connectionToken)
-            characteristicsHandle = NotificationCenter.default.addObserver(forName: .discoveredCharacteristic, object: nil, queue: .main) { _ in
+            characteristicsHandle = NotificationCenter.default.addObserver(forName: .discoveredCharacteristic, object: nil, queue: .main) { notification in
+                guard notification.userInfo?["peripheral uuid"] as! UUID == peripheral.identifier else { return }
                 self.connectionInProgress = false
                 completion(.success)
-                guard let contextHandle = characteristicsHandle else { return }
-                NotificationCenter.default.removeObserver(contextHandle)
+                guard let characteristicsHandle = characteristicsHandle else { return }
+                NotificationCenter.default.removeObserver(characteristicsHandle)
             }
         }
     }

--- a/AirCasting/ABConnector/AirBeamServices.swift
+++ b/AirCasting/ABConnector/AirBeamServices.swift
@@ -42,7 +42,7 @@ class ConnectingAirBeamServicesBluetooth: ConnectingAirBeamServices {
             var characteristicsHandle: Any?
             NotificationCenter.default.removeObserver(self.connectionToken)
             characteristicsHandle = NotificationCenter.default.addObserver(forName: .discoveredCharacteristic, object: nil, queue: .main) { notification in
-                guard notification.userInfo?["peripheral uuid"] as! UUID == peripheral.identifier else { return }
+                guard notification.userInfo?[AirCastingNotificationKeys.DiscoveredCharacteristic.peripheralUUID] as! UUID == peripheral.identifier else { return }
                 self.connectionInProgress = false
                 completion(.success)
                 guard let characteristicsHandle = characteristicsHandle else { return }

--- a/AirCasting/ABConnector/BluetoothManager.swift
+++ b/AirCasting/ABConnector/BluetoothManager.swift
@@ -110,15 +110,19 @@ extension BluetoothManager: CBCentralManagerDelegate {
     func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
         // Here's code for getting data from AB.
         peripheral.delegate = self
-        peripheral.discoverServices(nil)
         if mobilePeripheralSessionManager.activeSessionInProgressWith(peripheral) {
-            DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(4)) {
+            var characteristicsHandle: Any?
+            characteristicsHandle = NotificationCenter.default.addObserver(forName: .discoveredCharacteristic, object: nil, queue: .main) { notification in
+                guard notification.userInfo?["peripheral uuid"] as! UUID == peripheral.identifier else { return }
                 self.mobileSessionReconnected = true
+                guard let characteristicsHandle = characteristicsHandle else { return }
+                NotificationCenter.default.removeObserver(characteristicsHandle)
             }
         } else {
             connectedPeripheral = peripheral
             NotificationCenter.default.post(name: .deviceConnected, object: nil, userInfo: [AirCastingNotificationKeys.DeviceConnected.uuid : peripheral.identifier])
         }
+        peripheral.discoverServices(nil)
     }
     
     func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
@@ -156,7 +160,7 @@ extension BluetoothManager: CBPeripheralDelegate {
                 }
             }
         }
-        hasSomeCharacteristics ? NotificationCenter.default.post(name: .discoveredCharacteristic, object: nil, userInfo: nil) : nil
+        hasSomeCharacteristics ? NotificationCenter.default.post(name: .discoveredCharacteristic, object: nil, userInfo: ["peripheral uuid" : peripheral.identifier]) : nil
     }
     
     func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {

--- a/AirCasting/ABConnector/BluetoothManager.swift
+++ b/AirCasting/ABConnector/BluetoothManager.swift
@@ -113,7 +113,7 @@ extension BluetoothManager: CBCentralManagerDelegate {
         if mobilePeripheralSessionManager.activeSessionInProgressWith(peripheral) {
             var characteristicsHandle: Any?
             characteristicsHandle = NotificationCenter.default.addObserver(forName: .discoveredCharacteristic, object: nil, queue: .main) { notification in
-                guard notification.userInfo?["peripheral uuid"] as! UUID == peripheral.identifier else { return }
+                guard notification.userInfo?[AirCastingNotificationKeys.DiscoveredCharacteristic.peripheralUUID] as! UUID == peripheral.identifier else { return }
                 self.mobileSessionReconnected = true
                 guard let characteristicsHandle = characteristicsHandle else { return }
                 NotificationCenter.default.removeObserver(characteristicsHandle)
@@ -160,7 +160,7 @@ extension BluetoothManager: CBPeripheralDelegate {
                 }
             }
         }
-        hasSomeCharacteristics ? NotificationCenter.default.post(name: .discoveredCharacteristic, object: nil, userInfo: ["peripheral uuid" : peripheral.identifier]) : nil
+        hasSomeCharacteristics ? NotificationCenter.default.post(name: .discoveredCharacteristic, object: nil, userInfo: [AirCastingNotificationKeys.DiscoveredCharacteristic.peripheralUUID : peripheral.identifier]) : nil
     }
     
     func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {

--- a/AirCasting/Utils/AirCastingNotifications.swift
+++ b/AirCasting/Utils/AirCastingNotifications.swift
@@ -12,4 +12,8 @@ enum AirCastingNotificationKeys {
     enum DeviceConnected {
         static let uuid = "uuid"
     }
+    
+    enum DiscoveredCharacteristic {
+        static let peripheralUUID = "peripheral uuid"
+    }
 }


### PR DESCRIPTION
* When reconnecting with device previously we were waiting 4 seconds before sending configuration. Now we are waiting for the discovered characteristic notification
* In the notification I added user info with a peripheral uuid just to double check that discovered characteristic notification is related to the right peripheral