### PR TITLE
fix endpoint - Backend URL

### DIFF
--- a/AirCasting/Settings/BackendSettingsView.swift
+++ b/AirCasting/Settings/BackendSettingsView.swift
@@ -56,7 +56,11 @@ struct BackendSettingsView: View {
     
     private var oKButton: some View {
         Button {
-            urlProvider.baseAppURL = url ?? URL(string: "http://aircasting.org/api")!
+            if url != nil  {
+                urlProvider.baseAppURL = url!.appendingPathComponent("/api")
+            } else {
+                urlProvider.baseAppURL = URL(string: "http://aircasting.org/api")!
+            }
             presentationMode.wrappedValue.dismiss()
             do {
                 userState.isLoggingOut = true


### PR DESCRIPTION
It appeared we had a bad endpoint (I mean not complete). When using some custom one we were missing /api. I've added it like that not to mess up anything else in the app and I think it is ok. 
Tested and working as expected :)