### PR TITLE
Release flags override fix

### DIFF
--- a/AirCasting/FeatureFlags/FeatureFlagProviders/OverridingFeatureFlagProvider.swift
+++ b/AirCasting/FeatureFlags/FeatureFlagProviders/OverridingFeatureFlagProvider.swift
@@ -8,16 +8,12 @@ class OverridingFeatureFlagProvider: FeatureFlagProvider {
     
     var onFeatureListChange: (() -> Void)?
     
-    #if DEBUG || BETA
     var overrides: [FeatureFlag: Bool] = [:] {
         didSet {
             onFeatureListChange?()
             UserDefaults.standard.set(toJsonDict(overrides), forKey: userDefaultsKey)
         }
     }
-    #else
-    private var overrides: [FeatureFlag: Bool] = [:]
-    #endif
     
     init() {
         guard let saved = UserDefaults.standard.dictionary(forKey: userDefaultsKey) as? [String: Bool] else { return }


### PR DESCRIPTION
After updating from beta/development builds to release the feature flag overrides were still in place and couldn't be switched without app reinstall