### PR TITLE
Get settings for crowd map from user defaults at the start of the app

### DIFF
--- a/AirCasting.xcodeproj/project.pbxproj
+++ b/AirCasting.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		33885BB227468B4E00F41CB5 /* SDSyncFileWritingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33885BB127468B4E00F41CB5 /* SDSyncFileWritingService.swift */; };
 		338C30E225F1044B00E0305C /* PersistenceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 338C30E125F1044B00E0305C /* PersistenceController.swift */; };
 		338C30E825F10BFE00E0305C /* AirCasting.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 338C30E625F10BFE00E0305C /* AirCasting.xcdatamodeld */; };
+		3397C81F2787024C0050B333 /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3397C81E2787024C0050B333 /* UserDefaults.swift */; };
 		33AC7D5C273C1B9700EB1274 /* StandaloneSessionCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AC7D5B273C1B9700EB1274 /* StandaloneSessionCardView.swift */; };
 		33BA3368266E4BCA00899343 /* MobilePeripheralSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BA3367266E4BCA00899343 /* MobilePeripheralSessionManager.swift */; };
 		33BA336A266E4D1000899343 /* MobileSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BA3369266E4D1000899343 /* MobileSession.swift */; };
@@ -373,6 +374,7 @@
 		33885BB127468B4E00F41CB5 /* SDSyncFileWritingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDSyncFileWritingService.swift; sourceTree = "<group>"; };
 		338C30E125F1044B00E0305C /* PersistenceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceController.swift; sourceTree = "<group>"; };
 		338C30E725F10BFE00E0305C /* AirCasting.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = AirCasting.xcdatamodel; sourceTree = "<group>"; };
+		3397C81E2787024C0050B333 /* UserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaults.swift; sourceTree = "<group>"; };
 		33AC7D5B273C1B9700EB1274 /* StandaloneSessionCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandaloneSessionCardView.swift; sourceTree = "<group>"; };
 		33BA3367266E4BCA00899343 /* MobilePeripheralSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobilePeripheralSessionManager.swift; sourceTree = "<group>"; };
 		33BA3369266E4D1000899343 /* MobileSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileSession.swift; sourceTree = "<group>"; };
@@ -1354,6 +1356,7 @@
 				B3D4B4B326C2C6A1004322FC /* Date+Miliseconds.swift */,
 				33F22389270C674E00F14909 /* TimeInterval.swift */,
 				DDCD356F271EB641004969FF /* UIImage.swift */,
+				3397C81E2787024C0050B333 /* UserDefaults.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2314,6 +2317,7 @@
 				AC524A7626133A370061AD45 /* MeaurementStreamExtension.swift in Sources */,
 				DDC5F58A271979F100F1F9D8 /* Fonts.swift in Sources */,
 				33F20FDD27692231004364EA /* SyncedMeasurementsDownloadingService.swift in Sources */,
+				3397C81F2787024C0050B333 /* UserDefaults.swift in Sources */,
 				DD28047726B3D6E70060F55E /* ConnectingAirBeamServices.swift in Sources */,
 				DD28047926B3D7370060F55E /* AirBeamConnectionController.swift in Sources */,
 				B367A594274E9EAA004C605B /* AppDelegate.swift in Sources */,

--- a/AirCasting/AuthViews/UserSettings.swift
+++ b/AirCasting/AuthViews/UserSettings.swift
@@ -6,7 +6,7 @@ import UIKit
 
 class UserSettings: ObservableObject {
     private let userDefaults: UserDefaults
-    let crowdMapKey = Constants.UserDefaultsKeys.crowdMap
+    private let crowdMapKey = Constants.UserDefaultsKeys.crowdMap
     
     var contributingToCrowdMap: Bool {
         get {

--- a/AirCasting/AuthViews/UserSettings.swift
+++ b/AirCasting/AuthViews/UserSettings.swift
@@ -6,13 +6,14 @@ import UIKit
 
 class UserSettings: ObservableObject {
     private let userDefaults: UserDefaults
+    let crowdMapKey = Constants.UserDefaultsKeys.crowdMap
     
     var contributingToCrowdMap: Bool {
         get {
-            userDefaults.bool(forKey: "crowdMap")
+            userDefaults.bool(forKey: crowdMapKey)
         }
         set {
-            userDefaults.setValue(newValue, forKey: "crowdMap")
+            userDefaults.setValue(newValue, forKey: crowdMapKey)
             Log.info("Changed crowdMap contribution setting to \(contributingToCrowdMap ? "ON" : "OFF")")
         }
     }
@@ -30,7 +31,7 @@ class UserSettings: ObservableObject {
     
     init(userDefaults: UserDefaults = .standard) {
         self.userDefaults = userDefaults
-        contributingToCrowdMap = true
+        contributingToCrowdMap = userDefaults.valueExists(forKey: crowdMapKey) ? userDefaults.bool(forKey: crowdMapKey) : true
         keepScreenOn = userDefaults.bool(forKey: "keepScreenOn")
     }
 }

--- a/AirCasting/Extensions/UserDefaults.swift
+++ b/AirCasting/Extensions/UserDefaults.swift
@@ -1,0 +1,12 @@
+// Created by Lunar on 06/01/2022.
+//
+
+import Foundation
+
+extension UserDefaults {
+
+    func valueExists(forKey key: String) -> Bool {
+        return object(forKey: key) != nil
+    }
+
+}

--- a/AirCasting/Utils/Constants.swift
+++ b/AirCasting/Utils/Constants.swift
@@ -29,4 +29,8 @@ struct Constants {
     enum SDCardSync {
         static let numberOfMeasurementsInDataChunk = 4
     }
+    
+    enum UserDefaultsKeys {
+        static let crowdMap = "crowdMap"
+    }
 }


### PR DESCRIPTION
This just adds a small fix to UserSettings. Previously we were always setting contributingToCrowdMap to true at the app launch and now we will take them from userdefautls