### PR TITLE
Session name empty - error

### DIFF
--- a/AirCasting/CreateSessionViews/CreateSessionDetails/CreateSessionDetailsView.swift
+++ b/AirCasting/CreateSessionViews/CreateSessionDetails/CreateSessionDetailsView.swift
@@ -22,7 +22,6 @@ struct CreateSessionDetailsView: View {
                         titleLabel
                         VStack(alignment: .leading) {
                             sessionNameField
-                                .onTapGesture { viewModel.nameTextFieldTapped() }
                             if viewModel.shouldShowError { errorMessage(text: Strings.EditSession.erorr) }
                             sessionTagsField
                                 .padding(.top, 20)
@@ -45,6 +44,9 @@ struct CreateSessionDetailsView: View {
             .background(navigation)
         }
         .onAppear { viewModel.onScreenEnter() }
+        .onChange(of: viewModel.sessionName) { _ in
+            viewModel.showErrorIndicator = false
+        }
     }
 }
 

--- a/AirCasting/CreateSessionViews/CreateSessionDetails/CreateSessionDetailsViewModel.swift
+++ b/AirCasting/CreateSessionViews/CreateSessionDetails/CreateSessionDetailsViewModel.swift
@@ -15,8 +15,8 @@ class CreateSessionDetailsViewModel: ObservableObject {
     @Published var isLocationSessionDetailsActive: Bool = false
     @Published var showAlertAboutEmptyCredentials = false
     @Published var isSSIDTextfieldDisplayed: Bool = false
-    var shouldShowError: Bool { sessionName.isEmpty && !yetNoInteraction }
-    private var yetNoInteraction = true
+    @Published var showErrorIndicator: Bool = false
+    var shouldShowError: Bool { sessionName.isEmpty && showErrorIndicator }
     
     let baseURL: BaseURLProvider
     // It cannot be private as long as it is going to be passed
@@ -24,10 +24,6 @@ class CreateSessionDetailsViewModel: ObservableObject {
     
     init(baseURL: BaseURLProvider) {
         self.baseURL = baseURL
-    }
-    
-    func nameTextFieldTapped() {
-        yetNoInteraction = false
     }
     
     func onScreenEnter() {
@@ -38,7 +34,7 @@ class CreateSessionDetailsViewModel: ObservableObject {
     func onContinueClick(sessionContext: CreateSessionContext) -> CreateSessionContext {
         // sessionContext is needed becouse it is being modified in the session creation proccess
         // by 'modified' I mean - the data it ovverriden by the proper one (get from user) on every step
-        guard !sessionName.isEmpty else { yetNoInteraction = false; return sessionContext }
+        guard !sessionName.isEmpty else { showErrorIndicator = true; return sessionContext }
         sessionContext.sessionName = sessionName
         sessionContext.sessionTags = sessionTags
         


### PR DESCRIPTION
Show error only when (from Michael):
. show this message only if: the session name field is blank AND the user taps "Continue".