### PR TITLE
Change locationless feature flag name: .disableMapping -> locationlessSessions

### DIFF
--- a/AirCasting/AuthViews/UserSettings.swift
+++ b/AirCasting/AuthViews/UserSettings.swift
@@ -7,7 +7,7 @@ import UIKit
 class UserSettings: ObservableObject {
     private let userDefaults: UserDefaults
     private let crowdMapKey = Constants.UserDefaultsKeys.crowdMap
-    private let locationLessKey = Constants.UserDefaultsKeys.disableMapping
+    private let locationlessKey = Constants.UserDefaultsKeys.disableMapping
     private let keepScreenOnKey = Constants.UserDefaultsKeys.keepScreenOn
     private let featureFlagsViewModel = FeatureFlagsViewModel.shared
     private let convertToCelsiusKey = Constants.UserDefaultsKeys.convertToCelsius
@@ -35,10 +35,10 @@ class UserSettings: ObservableObject {
 
     var disableMapping: Bool {
         get {
-            userDefaults.bool(forKey: locationLessKey)
+            userDefaults.bool(forKey: locationlessKey)
         }
         set {
-            userDefaults.setValue(newValue, forKey: locationLessKey)
+            userDefaults.setValue(newValue, forKey: locationlessKey)
             Log.info("Changed locationless sessions setting to \(disableMapping ? "ON" : "OFF")")
         }
     }
@@ -58,7 +58,7 @@ class UserSettings: ObservableObject {
         contributingToCrowdMap = userDefaults.valueExists(forKey: crowdMapKey) ? userDefaults.bool(forKey: crowdMapKey) : true
         keepScreenOn = userDefaults.bool(forKey: keepScreenOnKey)
         // This is included in case user turns on disable mapping but we turn off the feature, because otherwise the user could never turn this off
-        disableMapping = featureFlagsViewModel.enabledFeatures.contains(.locationlessSessions) ? userDefaults.bool(forKey: locationLessKey) : false
+        disableMapping = featureFlagsViewModel.enabledFeatures.contains(.locationlessSessions) ? userDefaults.bool(forKey: locationlessKey) : false
         convertToCelsius = userDefaults.bool(forKey: convertToCelsiusKey)
     }
 }

--- a/AirCasting/AuthViews/UserSettings.swift
+++ b/AirCasting/AuthViews/UserSettings.swift
@@ -7,7 +7,7 @@ import UIKit
 class UserSettings: ObservableObject {
     private let userDefaults: UserDefaults
     private let crowdMapKey = Constants.UserDefaultsKeys.crowdMap
-    private let disableMappingKey = Constants.UserDefaultsKeys.disableMapping
+    private let locationLessKey = Constants.UserDefaultsKeys.disableMapping
     private let keepScreenOnKey = Constants.UserDefaultsKeys.keepScreenOn
     private let featureFlagsViewModel = FeatureFlagsViewModel.shared
     private let convertToCelsiusKey = Constants.UserDefaultsKeys.convertToCelsius
@@ -35,11 +35,11 @@ class UserSettings: ObservableObject {
 
     var disableMapping: Bool {
         get {
-            userDefaults.bool(forKey: disableMappingKey)
+            userDefaults.bool(forKey: locationLessKey)
         }
         set {
-            userDefaults.setValue(newValue, forKey: disableMappingKey)
-            Log.info("Changed disable mapping setting to \(disableMapping ? "ON" : "OFF")")
+            userDefaults.setValue(newValue, forKey: locationLessKey)
+            Log.info("Changed locationless sessions setting to \(disableMapping ? "ON" : "OFF")")
         }
     }
 
@@ -58,7 +58,7 @@ class UserSettings: ObservableObject {
         contributingToCrowdMap = userDefaults.valueExists(forKey: crowdMapKey) ? userDefaults.bool(forKey: crowdMapKey) : true
         keepScreenOn = userDefaults.bool(forKey: keepScreenOnKey)
         // This is included in case user turns on disable mapping but we turn off the feature, because otherwise the user could never turn this off
-        disableMapping = featureFlagsViewModel.enabledFeatures.contains(.disableMapping) ? userDefaults.bool(forKey: disableMappingKey) : false
+        disableMapping = featureFlagsViewModel.enabledFeatures.contains(.locationlessSessions) ? userDefaults.bool(forKey: locationLessKey) : false
         convertToCelsius = userDefaults.bool(forKey: convertToCelsiusKey)
     }
 }

--- a/AirCasting/FeatureFlags/FeatureFlagProvider.swift
+++ b/AirCasting/FeatureFlags/FeatureFlagProvider.swift
@@ -4,7 +4,7 @@ enum FeatureFlag: String, Equatable, CaseIterable {
     case sdCardSync
     case standaloneMode
     case notes
-    case disableMapping
+    case locationlessSessions
 }
 
 extension FeatureFlag {
@@ -13,7 +13,7 @@ extension FeatureFlag {
         case .standaloneMode: return "Standalone mode"
         case .sdCardSync: return "SD Card sync"
         case .notes: return "Session notes"
-        case .disableMapping: return "Disable Mapping"
+        case .locationlessSessions: return "Disable Mapping"
         }
     }
 }

--- a/AirCasting/FeatureFlags/FeatureFlagProviders/DefaultFeatureFlagProvider.swift
+++ b/AirCasting/FeatureFlags/FeatureFlagProviders/DefaultFeatureFlagProvider.swift
@@ -21,7 +21,7 @@ class DefaultFeatureFlagProvider: FeatureFlagProvider {
             #else
             return false
             #endif
-        case .disableMapping:
+        case .locationlessSessions:
             #if DEBUG
             return true
             #else

--- a/AirCasting/FeatureFlags/FeatureFlagProviders/FirebaseFeatureFlagProvider.swift
+++ b/AirCasting/FeatureFlags/FeatureFlagProviders/FirebaseFeatureFlagProvider.swift
@@ -46,7 +46,7 @@ class FirebaseFeatureFlagProvider: FeatureFlagProvider {
         case .sdCardSync: return "sd_card_sync"
         case .standaloneMode: return "standalone_mode"
         case .notes: return "session_notes"
-        case .disableMapping: return "disable_mapping"
+        case .locationlessSessions: return "locationless_sessions"
         }
     }
     

--- a/AirCasting/Settings/SettingsView.swift
+++ b/AirCasting/Settings/SettingsView.swift
@@ -127,7 +127,7 @@ struct SettingsView: View {
                 Spacer()
                 crowdMapDescription
             }
-            if featureFlagsViewModel.enabledFeatures.contains(.disableMapping) {
+            if featureFlagsViewModel.enabledFeatures.contains(.locationlessSessions) {
                 disableMappingSwitch
             }
             keepScreenOnSwitch


### PR DESCRIPTION
It's much easier to read when a feture always *turns something on*, not off.

Kudos to @anna1901 for a great name suggestion 🚀