### PR TITLE
Sort notes before uploding to web.

### DIFF
--- a/AirCasting/SessionsSynchronization/Controller/Utils/SessionsSynchronizationStoreDataConverter.swift
+++ b/AirCasting/SessionsSynchronization/Controller/Utils/SessionsSynchronizationStoreDataConverter.swift
@@ -55,7 +55,7 @@ struct SynchronizationDataConverter {
         return .init(uuid: session.uuid,
                      type: session.sessionType,
                      title: session.name,
-                     notes: convertDatabaseNotesToMetadata(session.notes),
+                     notes: convertDatabaseNotesToMetadata(session.notes).sorted(by: { $0.number < $1.number }),
                      tagList: session.tags ?? "",
                      startTime: session.startTime,
                      endTime: session.endTime,

--- a/AirCasting/SingleSessionSynchronizer/SessionUpdateService.swift
+++ b/AirCasting/SingleSessionSynchronizer/SessionUpdateService.swift
@@ -64,7 +64,7 @@ class DefaultSessionUpdateService: SessionUpdateService {
                                                            end_time: session.endTime ?? Date(),
                                                            contribute: session.contribute,
                                                            is_indoor: session.isIndoor,
-                                                           notes: notes,
+                                                           notes: notes.sorted(by: { $0.number < $1.number }),
                                                            version: Int(session.version),
                                                            streams: data,
                                                            latitude: session.location?.latitude,


### PR DESCRIPTION
https://trello.com/c/qUetu2QY/513-sort-notes-before-sending-to-web
Notes need to be sorted, before being uploaded on the web. It results in placing them in the right order.