### PR TITLE
Alligning graph and map the same way.

### DIFF
--- a/AirCasting/Map/AirMapView.swift
+++ b/AirCasting/Map/AirMapView.swift
@@ -122,10 +122,9 @@ struct AirMapView: View {
                     ThresholdsSliderView(threshold: threshold)
                         // Fixes labels covered by tabbar
                         .padding([.bottom, .leading, .trailing])
-                } else {
-                    Spacer()
                 }
             }
+            Spacer()
         }
         .sheet(isPresented: $noteMarkerTapped, content: {
             EditNoteView(viewModel: EditNoteViewModelDefault(exitRoute: {


### PR DESCRIPTION
For now, graph was able to push everything to the top, when there was no measurements. The map was not able to do it, now it matches the grpah convention and it can.


https://trello.com/c/Jzmj9B7B/497-fix-ui-alignment-airbeam-session