### PR TITLE
Location screen for fixed session moved.

### DIFF
--- a/AirCasting.xcodeproj/project.pbxproj
+++ b/AirCasting.xcodeproj/project.pbxproj
@@ -323,6 +323,8 @@
 		DD8C380E2689A55A00901FDF /* BackendSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD8C380D2689A55A00901FDF /* BackendSettingsView.swift */; };
 		DD8DE6892785B706009B1726 /* EmptyNotesHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD8DE6882785B706009B1726 /* EmptyNotesHandler.swift */; };
 		DD8DE68B2785B93A009B1726 /* MapNotesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD8DE68A2785B939009B1726 /* MapNotesViewModel.swift */; };
+		DD9DD37327A2B91A00E657E4 /* TurnOnLocationFixedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9DD37227A2B91A00E657E4 /* TurnOnLocationFixedView.swift */; };
+		DD9DD37527A2B92E00E657E4 /* TurnOnLocationFixedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9DD37427A2B92E00E657E4 /* TurnOnLocationFixedViewModel.swift */; };
 		DD9EBB4E26AFDD2100D51804 /* TurnOnLocationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9EBB4D26AFDD2100D51804 /* TurnOnLocationView.swift */; };
 		DD9EBFD5279EB70900192CB5 /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9EBFD4279EB70900192CB5 /* TextView.swift */; };
 		DD9EBFD8279EEAB300192CB5 /* DataBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9EBFD7279EEAB300192CB5 /* DataBuilder.swift */; };
@@ -703,6 +705,8 @@
 		DD8C380F268A0E9400901FDF /* ShareViewModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewModal.swift; sourceTree = "<group>"; };
 		DD8DE6882785B706009B1726 /* EmptyNotesHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyNotesHandler.swift; sourceTree = "<group>"; };
 		DD8DE68A2785B939009B1726 /* MapNotesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapNotesViewModel.swift; sourceTree = "<group>"; };
+		DD9DD37227A2B91A00E657E4 /* TurnOnLocationFixedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnOnLocationFixedView.swift; sourceTree = "<group>"; };
+		DD9DD37427A2B92E00E657E4 /* TurnOnLocationFixedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnOnLocationFixedViewModel.swift; sourceTree = "<group>"; };
 		DD9EBB4D26AFDD2100D51804 /* TurnOnLocationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnOnLocationView.swift; sourceTree = "<group>"; };
 		DD9EBFD4279EB70900192CB5 /* TextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextView.swift; sourceTree = "<group>"; };
 		DD9EBFD7279EEAB300192CB5 /* DataBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBuilder.swift; sourceTree = "<group>"; };
@@ -997,6 +1001,7 @@
 				AC32041E25CC485E00A68520 /* ConnectingABView.swift */,
 				AC960C7725DD39F500EC95DD /* ABConnectedView.swift */,
 				DD4108F8273BE92700BF10FF /* CreateSessionDetails */,
+				DD9DD37127A2B8EE00E657E4 /* TurnOnLocationFixed */,
 				DD8A36A326C3CE7900C26725 /* ChooseCustomLocationView.swift */,
 				DD8A36A626C3E76200C26725 /* PlacePicker.swift */,
 				331EA80925E32094009DEFDB /* ConfirmCreatingSessionView.swift */,
@@ -1824,6 +1829,15 @@
 			path = URLProviders;
 			sourceTree = "<group>";
 		};
+		DD9DD37127A2B8EE00E657E4 /* TurnOnLocationFixed */ = {
+			isa = PBXGroup;
+			children = (
+				DD9DD37227A2B91A00E657E4 /* TurnOnLocationFixedView.swift */,
+				DD9DD37427A2B92E00E657E4 /* TurnOnLocationFixedViewModel.swift */,
+			);
+			path = TurnOnLocationFixed;
+			sourceTree = "<group>";
+		};
 		DDB0557F274BC5AF00DA1A8A /* SingleSessionSynchronizer */ = {
 			isa = PBXGroup;
 			children = (
@@ -2334,6 +2348,7 @@
 				4F945EEE2649F3F5008A5B22 /* SessionCreator.swift in Sources */,
 				4F945EF02649F455008A5B22 /* AirBeamFixedWifiSessionCreator.swift in Sources */,
 				B30BAC132694AA3200AE0476 /* MeasurementsStatisticsController.swift in Sources */,
+				DD9DD37527A2B92E00E657E4 /* TurnOnLocationFixedViewModel.swift in Sources */,
 				DDC3E954275E4C3A0066A5DF /* SettingsViewModel.swift in Sources */,
 				33769A5C2705B06F007D1EA7 /* ChartViewModel.swift in Sources */,
 				33BA3368266E4BCA00899343 /* MobilePeripheralSessionManager.swift in Sources */,
@@ -2405,6 +2420,7 @@
 				B376DD25268096E20083FD2F /* SessionSynchronizationDatabase.swift in Sources */,
 				AC6D56A525AF211200D221BA /* MultiSliderView.swift in Sources */,
 				AC524A7626133A370061AD45 /* MeaurementStreamExtension.swift in Sources */,
+				DD9DD37327A2B91A00E657E4 /* TurnOnLocationFixedView.swift in Sources */,
 				DDC5F58A271979F100F1F9D8 /* Fonts.swift in Sources */,
 				33F20FDD27692231004364EA /* SyncedMeasurementsDownloadingService.swift in Sources */,
 				3397C81F2787024C0050B333 /* UserDefaults.swift in Sources */,

--- a/AirCasting/CreateSessionViews/ABConnectedView.swift
+++ b/AirCasting/CreateSessionViews/ABConnectedView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct ABConnectedView: View {
     @Binding var creatingSessionFlowContinues: Bool
     let baseURL: BaseURLProvider
+    let locationHandler: LocationHandler
     
     var body: some View {
         VStack() {
@@ -46,7 +47,7 @@ private extension ABConnectedView {
 
     var continueButton: some View {
         return NavigationLink(
-            destination: CreateSessionDetailsView(creatingSessionFlowContinues: $creatingSessionFlowContinues, baseURL: baseURL),
+            destination: CreateSessionDetailsView(creatingSessionFlowContinues: $creatingSessionFlowContinues, baseURL: baseURL, locationHandler: locationHandler),
             label: {
                 Text(Strings.Commons.continue)
             })

--- a/AirCasting/CreateSessionViews/ChooseCustomLocationView.swift
+++ b/AirCasting/CreateSessionViews/ChooseCustomLocationView.swift
@@ -10,7 +10,7 @@ struct ChooseCustomLocationView: View {
     @State var placePickerPresented: Bool = false
     @State var isLocationPopupPresented = false
     @Binding var creatingSessionFlowContinues: Bool
-    @Binding var sessionName: String
+    var sessionName: String
     let baseURL: BaseURLProvider
 
     var body: some View {

--- a/AirCasting/CreateSessionViews/ChooseSessionType/ChooseSessionTypeView.swift
+++ b/AirCasting/CreateSessionViews/ChooseSessionType/ChooseSessionTypeView.swift
@@ -41,7 +41,8 @@ struct ChooseSessionTypeView: View {
                 .fullScreenCover(isPresented: $isPowerABLinkActive) {
                     CreatingSessionFlowRootView {
                         PowerABView(creatingSessionFlowContinues: $isPowerABLinkActive,
-                                    urlProvider: viewModel.passURLProvider)
+                                    urlProvider: viewModel.passURLProvider,
+                                    locationHandler: viewModel.locationHandler)
                     }
                 }
             
@@ -60,7 +61,7 @@ struct ChooseSessionTypeView: View {
                     CreatingSessionFlowRootView {
                         TurnOnBluetoothView(creatingSessionFlowContinues: $isTurnBluetoothOnLinkActive,
                                             sdSyncContinues: .constant(false),
-                                            urlProvider: viewModel.passURLProvider)
+                                            locationHandler: viewModel.locationHandler, urlProvider: viewModel.passURLProvider)
                     }
                 }
 
@@ -68,6 +69,7 @@ struct ChooseSessionTypeView: View {
                     CreatingSessionFlowRootView {
                         SelectDeviceView(creatingSessionFlowContinues: $isMobileLinkActive,
                                          sdSyncContinues: .constant(false),
+                                         locationHandler: viewModel.locationHandler,
                                          urlProvider: viewModel.passURLProvider)
                     }
                 }
@@ -102,7 +104,8 @@ struct ChooseSessionTypeView: View {
                             .fullScreenCover(isPresented: $isPowerABLinkActive) {
                                 CreatingSessionFlowRootView {
                                     PowerABView(creatingSessionFlowContinues: $isPowerABLinkActive,
-                                                urlProvider: viewModel.passURLProvider)
+                                                urlProvider: viewModel.passURLProvider,
+                                                locationHandler: viewModel.locationHandler)
                                 }
                             }
                         EmptyView()
@@ -120,7 +123,7 @@ struct ChooseSessionTypeView: View {
                                 CreatingSessionFlowRootView {
                                     TurnOnBluetoothView(creatingSessionFlowContinues: $isTurnBluetoothOnLinkActive,
                                                         sdSyncContinues: .constant(false),
-                                                        urlProvider: viewModel.passURLProvider)
+                                                        locationHandler: viewModel.locationHandler, urlProvider: viewModel.passURLProvider)
                                 }
                             }
                         EmptyView()
@@ -128,7 +131,7 @@ struct ChooseSessionTypeView: View {
                                 CreatingSessionFlowRootView {
                                     SelectDeviceView(creatingSessionFlowContinues: $isMobileLinkActive,
                                                      sdSyncContinues: .constant(false),
-                                                     urlProvider: viewModel.passURLProvider)
+                                                     locationHandler: viewModel.locationHandler, urlProvider: viewModel.passURLProvider)
                                 }
                             }
                         EmptyView()
@@ -239,7 +242,6 @@ struct ChooseSessionTypeView: View {
             viewModel.createNewSession(isSessionFixed: true)
             switch viewModel.fixedSessionNextStep() {
             case .airBeam: isPowerABLinkActive = true
-            case .location: isTurnLocationOnLinkActive = true
             case .bluetooth: isTurnBluetoothOnLinkActive = true
             default: return
             }

--- a/AirCasting/CreateSessionViews/ChooseSessionType/ChooseSessionTypeViewModel.swift
+++ b/AirCasting/CreateSessionViews/ChooseSessionType/ChooseSessionTypeViewModel.swift
@@ -56,7 +56,6 @@ class ChooseSessionTypeViewModel {
     }
 
     func fixedSessionNextStep() -> ProceedToView {
-        guard !locationHandler.isLocationDenied() else { return .location }
         guard !bluetoothHandler.isBluetoothDenied() else { return .bluetooth }
         return .airBeam
     }

--- a/AirCasting/CreateSessionViews/ConnectingABView.swift
+++ b/AirCasting/CreateSessionViews/ConnectingABView.swift
@@ -14,6 +14,7 @@ struct ConnectingABView<VM: AirbeamConnectionViewModel>: View {
     @Environment(\.presentationMode) var presentationMode
     @StateObject var viewModel: VM
     let baseURL: BaseURLProvider
+    let locationHandler: LocationHandler
     @Binding var creatingSessionFlowContinues: Bool
     @State private var showNextScreen: Bool = false
     @State private var presentAlert: Bool = false
@@ -40,7 +41,7 @@ struct ConnectingABView<VM: AirbeamConnectionViewModel>: View {
         }
         .background(
             NavigationLink(
-                destination: ABConnectedView(creatingSessionFlowContinues: $creatingSessionFlowContinues, baseURL: baseURL),
+                destination: ABConnectedView(creatingSessionFlowContinues: $creatingSessionFlowContinues, baseURL: baseURL, locationHandler: locationHandler),
                 isActive: $showNextScreen,
                 label: {
                     EmptyView()

--- a/AirCasting/CreateSessionViews/CreateSessionDetails/CreateSessionDetailsView.swift
+++ b/AirCasting/CreateSessionViews/CreateSessionDetails/CreateSessionDetailsView.swift
@@ -9,9 +9,9 @@ struct CreateSessionDetailsView: View {
     @StateObject private var viewModel: CreateSessionDetailsViewModel
     @Binding var creatingSessionFlowContinues: Bool
     
-    init(creatingSessionFlowContinues: Binding<Bool>, baseURL: BaseURLProvider) {
+    init(creatingSessionFlowContinues: Binding<Bool>, baseURL: BaseURLProvider, locationHandler: LocationHandler) {
         self._creatingSessionFlowContinues = creatingSessionFlowContinues
-        self._viewModel = .init(wrappedValue: CreateSessionDetailsViewModel(baseURL: baseURL))
+        self._viewModel = .init(wrappedValue: CreateSessionDetailsViewModel(baseURL: baseURL, locationHandler: locationHandler))
     }
     
     var body: some View {
@@ -115,7 +115,7 @@ private extension CreateSessionDetailsView {
     var locationPickerLink: some View {
         NavigationLink(
             destination: ChooseCustomLocationView(creatingSessionFlowContinues: $creatingSessionFlowContinues,
-                                                  sessionName: $viewModel.sessionName, baseURL: viewModel.baseURL),
+                                                  sessionName: viewModel.sessionName, baseURL: viewModel.baseURL),
             isActive: $viewModel.isLocationSessionDetailsActive,
             label: {
                 EmptyView()
@@ -128,6 +128,19 @@ private extension CreateSessionDetailsView {
             destination: ConfirmCreatingSessionView(creatingSessionFlowContinues: $creatingSessionFlowContinues,
                                                     baseURL: viewModel.baseURL, sessionName: viewModel.sessionName),
             isActive: $viewModel.isConfirmCreatingSessionActive,
+            label: {
+                EmptyView()
+            }
+        )
+    }
+    
+    var locationLink: some View {
+        NavigationLink(
+            destination: TurnOnLocationFixedView(creatingSessionFlowContinues:  $creatingSessionFlowContinues,
+                                                 viewModel: .init(locationHandler: viewModel.locationHandler,
+                                                                  sessionContext: sessionContext,
+                                                                  urlProvider: viewModel.baseURL)),
+            isActive: $viewModel.isLocationScreenNedeed,
             label: {
                 EmptyView()
             }

--- a/AirCasting/CreateSessionViews/CreateSessionDetails/CreateSessionDetailsView.swift
+++ b/AirCasting/CreateSessionViews/CreateSessionDetails/CreateSessionDetailsView.swift
@@ -109,6 +109,7 @@ private extension CreateSessionDetailsView {
         ZStack {
             locationPickerLink
             createSesssionLink
+            locationLink
         }
     }
     
@@ -117,17 +118,6 @@ private extension CreateSessionDetailsView {
             destination: ChooseCustomLocationView(creatingSessionFlowContinues: $creatingSessionFlowContinues,
                                                   sessionName: viewModel.sessionName, baseURL: viewModel.baseURL),
             isActive: $viewModel.isLocationSessionDetailsActive,
-            label: {
-                EmptyView()
-            }
-        )
-    }
-    
-    var createSesssionLink: some View {
-        NavigationLink(
-            destination: ConfirmCreatingSessionView(creatingSessionFlowContinues: $creatingSessionFlowContinues,
-                                                    baseURL: viewModel.baseURL, sessionName: viewModel.sessionName),
-            isActive: $viewModel.isConfirmCreatingSessionActive,
             label: {
                 EmptyView()
             }
@@ -146,6 +136,18 @@ private extension CreateSessionDetailsView {
             }
         )
     }
+    
+    var createSesssionLink: some View {
+        NavigationLink(
+            destination: ConfirmCreatingSessionView(creatingSessionFlowContinues: $creatingSessionFlowContinues,
+                                                    baseURL: viewModel.baseURL, sessionName: viewModel.sessionName),
+            isActive: $viewModel.isConfirmCreatingSessionActive,
+            label: {
+                EmptyView()
+            }
+        )
+    }
+    
     
     var continueButton: some View {
         Button(action: {

--- a/AirCasting/CreateSessionViews/CreateSessionDetails/CreateSessionDetailsViewModel.swift
+++ b/AirCasting/CreateSessionViews/CreateSessionDetails/CreateSessionDetailsViewModel.swift
@@ -13,17 +13,21 @@ class CreateSessionDetailsViewModel: ObservableObject {
     @Published var wifiSSID: String = ""
     @Published var isConfirmCreatingSessionActive: Bool = false
     @Published var isLocationSessionDetailsActive: Bool = false
+    @Published var isLocationScreenNedeed: Bool = false
     @Published var showAlertAboutEmptyCredentials = false
     @Published var isSSIDTextfieldDisplayed: Bool = false
     @Published var showErrorIndicator: Bool = false
     var shouldShowError: Bool { sessionName.isEmpty && showErrorIndicator }
+    let locationHandler: LocationHandler
+    
     
     let baseURL: BaseURLProvider
     // It cannot be private as long as it is going to be passed
     // by every view which is included in session creation process
     
-    init(baseURL: BaseURLProvider) {
+    init(baseURL: BaseURLProvider, locationHandler: LocationHandler) {
         self.baseURL = baseURL
+        self.locationHandler = locationHandler
     }
     
     func onScreenEnter() {
@@ -64,8 +68,12 @@ class CreateSessionDetailsViewModel: ObservableObject {
     
     func compareIsIndoor(sessionContext: CreateSessionContext) -> CreateSessionContext {
         sessionContext.isIndoor = isIndoor
-        isLocationSessionDetailsActive = !isIndoor
-        isConfirmCreatingSessionActive = isIndoor
+        guard locationHandler.isLocationDenied() && !(sessionContext.isIndoor != nil) else {
+            isLocationSessionDetailsActive = !isIndoor
+            isConfirmCreatingSessionActive = isIndoor
+            return sessionContext
+        }
+        isLocationScreenNedeed = true
         return sessionContext
     }
     

--- a/AirCasting/CreateSessionViews/CreateSessionDetails/CreateSessionDetailsViewModel.swift
+++ b/AirCasting/CreateSessionViews/CreateSessionDetails/CreateSessionDetailsViewModel.swift
@@ -68,7 +68,7 @@ class CreateSessionDetailsViewModel: ObservableObject {
     
     func compareIsIndoor(sessionContext: CreateSessionContext) -> CreateSessionContext {
         sessionContext.isIndoor = isIndoor
-        guard locationHandler.isLocationDenied() && !(sessionContext.isIndoor != nil) else {
+        guard locationHandler.isLocationDenied() && !isIndoor else {
             isLocationSessionDetailsActive = !isIndoor
             isConfirmCreatingSessionActive = isIndoor
             return sessionContext

--- a/AirCasting/CreateSessionViews/PowerABView.swift
+++ b/AirCasting/CreateSessionViews/PowerABView.swift
@@ -12,6 +12,7 @@ struct PowerABView: View {
     @Binding var creatingSessionFlowContinues: Bool
     @EnvironmentObject private var sessionContext: CreateSessionContext
     let urlProvider: BaseURLProvider
+    let locationHandler: LocationHandler
 
     var body: some View {
         VStack() {
@@ -49,17 +50,9 @@ struct PowerABView: View {
     }
 
     var continueButton: some View {
-        NavigationLink(destination: SelectPeripheralView(SDClearingRouteProcess: false, creatingSessionFlowContinues: $creatingSessionFlowContinues, urlProvider: urlProvider)) {
+        NavigationLink(destination: SelectPeripheralView(SDClearingRouteProcess: false, creatingSessionFlowContinues: $creatingSessionFlowContinues, urlProvider: urlProvider, locationHandler: locationHandler)) {
             Text(Strings.Commons.continue)
                 .frame(maxWidth: .infinity)
         }
     }
 }
-
-#if DEBUG
-struct PowerABView_Previews: PreviewProvider {
-    static var previews: some View {
-        PowerABView(creatingSessionFlowContinues: .constant(true), urlProvider: DummyURLProvider())
-    }
-}
-#endif

--- a/AirCasting/CreateSessionViews/SelectDeviceView.swift
+++ b/AirCasting/CreateSessionViews/SelectDeviceView.swift
@@ -21,6 +21,7 @@ struct SelectDeviceView: View {
     @Binding var creatingSessionFlowContinues : Bool
     @Binding var sdSyncContinues : Bool
     @State private var showAlert = false
+    let locationHandler: LocationHandler
     @EnvironmentObject private var emptyDashboardButtonTapped: EmptyDashboardButtonTapped
     @EnvironmentObject private var tabSelection: TabBarSelection
 
@@ -39,19 +40,19 @@ struct SelectDeviceView: View {
         .padding()
         .background( Group {
             NavigationLink(
-                destination: PowerABView(creatingSessionFlowContinues: $creatingSessionFlowContinues, urlProvider: urlProvider),
+                destination: PowerABView(creatingSessionFlowContinues: $creatingSessionFlowContinues, urlProvider: urlProvider, locationHandler: locationHandler),
                 isActive: $isPowerABLinkActive,
                 label: {
                     EmptyView()
                 })
             NavigationLink(
-                destination: TurnOnBluetoothView(creatingSessionFlowContinues: $creatingSessionFlowContinues, sdSyncContinues: $sdSyncContinues, urlProvider: urlProvider),
+                destination: TurnOnBluetoothView(creatingSessionFlowContinues: $creatingSessionFlowContinues, sdSyncContinues: $sdSyncContinues, locationHandler: locationHandler, urlProvider: urlProvider),
                 isActive: $isTurnOnBluetoothLinkActive,
                 label: {
                     EmptyView()
                 })
             NavigationLink(
-                destination: CreateSessionDetailsView(creatingSessionFlowContinues: $creatingSessionFlowContinues, baseURL: urlProvider),
+                destination: CreateSessionDetailsView(creatingSessionFlowContinues: $creatingSessionFlowContinues, baseURL: urlProvider, locationHandler: locationHandler),
                 isActive: $isMicLinkActive,
                 label: {
                     EmptyView()

--- a/AirCasting/CreateSessionViews/SelectPeripheralView.swift
+++ b/AirCasting/CreateSessionViews/SelectPeripheralView.swift
@@ -18,6 +18,7 @@ struct SelectPeripheralView: View {
     @EnvironmentObject var sdSyncController: SDSyncController
     @Binding var creatingSessionFlowContinues: Bool
     let urlProvider: BaseURLProvider
+    let locationHandler: LocationHandler
     @EnvironmentObject var userAuthenticationSession: UserAuthenticationSession
     var syncMode: Bool? = false
     
@@ -149,7 +150,7 @@ struct SelectPeripheralView: View {
                                                   userAuthenticationSession: userAuthenticationSession,
                                                   sessionContext: sessionContext,
                                                   peripheral: selection)
-                destination = AnyView(ConnectingABView(viewModel: viewModel, baseURL: urlProvider, creatingSessionFlowContinues: $creatingSessionFlowContinues))
+                destination = AnyView(ConnectingABView(viewModel: viewModel, baseURL: urlProvider, locationHandler: locationHandler, creatingSessionFlowContinues: $creatingSessionFlowContinues))
             }
         } else {
             destination = AnyView(EmptyView())
@@ -160,11 +161,3 @@ struct SelectPeripheralView: View {
         .buttonStyle(BlueButtonStyle())
     }
 }
-
-#if DEBUG
-struct SelectPeripheralView_Previews: PreviewProvider {
-    static var previews: some View {
-        SelectPeripheralView(SDClearingRouteProcess: false, creatingSessionFlowContinues: .constant(true), urlProvider: DummyURLProvider())
-    }
-}
-#endif

--- a/AirCasting/CreateSessionViews/TurnOnBluetoothView.swift
+++ b/AirCasting/CreateSessionViews/TurnOnBluetoothView.swift
@@ -18,7 +18,7 @@ struct TurnOnBluetoothView: View {
     @Binding var creatingSessionFlowContinues: Bool
     @Binding var sdSyncContinues: Bool
     var isSDClearProcess: Bool = false
-
+    let locationHandler: LocationHandler
     let urlProvider: BaseURLProvider
 
     var body: some View {
@@ -37,7 +37,7 @@ struct TurnOnBluetoothView: View {
         .background(
             Group {
             NavigationLink(
-                destination: PowerABView(creatingSessionFlowContinues: $creatingSessionFlowContinues, urlProvider: urlProvider),
+                destination: PowerABView(creatingSessionFlowContinues: $creatingSessionFlowContinues, urlProvider: urlProvider, locationHandler: locationHandler),
                 isActive: $isPowerABLinkActive,
                 label: {
                     EmptyView()

--- a/AirCasting/CreateSessionViews/TurnOnLocation/TurnOnLocationView.swift
+++ b/AirCasting/CreateSessionViews/TurnOnLocation/TurnOnLocationView.swift
@@ -63,7 +63,8 @@ struct TurnOnLocationView: View {
     var proceedToPowerABView: some View {
         NavigationLink(
             destination: PowerABView(creatingSessionFlowContinues: $creatingSessionFlowContinues,
-                                     urlProvider: viewModel.passURLProvider),
+                                     urlProvider: viewModel.passURLProvider,
+                                     locationHandler: viewModel.locationHandler),
             isActive: $viewModel.isPowerABLinkActive,
             label: {
                 EmptyView()
@@ -74,7 +75,7 @@ struct TurnOnLocationView: View {
             destination: TurnOnBluetoothView(creatingSessionFlowContinues: $creatingSessionFlowContinues,
                                              sdSyncContinues: .constant(false),
                                              isSDClearProcess: viewModel.isSDClearProcess,
-                                             urlProvider: viewModel.passURLProvider),
+                                             locationHandler: viewModel.locationHandler, urlProvider: viewModel.passURLProvider),
             isActive: $viewModel.isTurnBluetoothOnLinkActive,
             label: {
                 EmptyView()
@@ -84,6 +85,7 @@ struct TurnOnLocationView: View {
         NavigationLink(
             destination: SelectDeviceView(creatingSessionFlowContinues: $creatingSessionFlowContinues,
                                           sdSyncContinues: .constant(false),
+                                          locationHandler: viewModel.locationHandler,
                                           urlProvider: viewModel.passURLProvider),
             isActive: $viewModel.isMobileLinkActive,
             label: {

--- a/AirCasting/CreateSessionViews/TurnOnLocation/TurnOnLocationViewModel.swift
+++ b/AirCasting/CreateSessionViews/TurnOnLocation/TurnOnLocationViewModel.swift
@@ -11,7 +11,7 @@ class TurnOnLocationViewModel: ObservableObject {
     @Published var alert: AlertInfo?
     var isSDClearProcess: Bool
     
-    private let locationHandler: LocationHandler
+    let locationHandler: LocationHandler
     private let bluetoothHandler: BluetoothHandler
     private let sessionContext: CreateSessionContext
     private let urlProvider: BaseURLProvider

--- a/AirCasting/CreateSessionViews/TurnOnLocationFixed/TurnOnLocationFixedView.swift
+++ b/AirCasting/CreateSessionViews/TurnOnLocationFixed/TurnOnLocationFixedView.swift
@@ -1,0 +1,85 @@
+// Created by Lunar on 27/01/2022.
+//
+
+import AirCastingStyling
+import SwiftUI
+
+struct TurnOnLocationFixedView: View {
+    @Binding var creatingSessionFlowContinues: Bool
+    @StateObject var viewModel: TurnOnLocationFixedViewModel
+    
+    var body: some View {
+        VStack(spacing: 50) {
+            ProgressView(value: 0.125)
+            Image("location-1")
+                .resizable()
+                .scaledToFit()
+            VStack(alignment: .leading, spacing: 15) {
+                titleLabel
+                messageLabel
+            }
+            continueButton
+        }
+        .padding()
+        .alert(item: $viewModel.alert, content: { $0.makeAlert() })
+        .background(
+            Group {
+                locationPickerLink
+                createSesssionLink
+            }
+        )
+        .onAppear {
+            viewModel.requestLocationAuthorisation()
+        }
+        .onChange(of: viewModel.shouldShowAlert) { newValue in
+            if newValue { viewModel.alert = InAppAlerts.locationAlert() }
+        }
+    }
+    
+    var titleLabel: some View {
+        Text(Strings.TurnOnLocationView.title)
+            .font(Fonts.boldTitle3)
+            .foregroundColor(.accentColor)
+    }
+    
+    var messageLabel: some View {
+        Text(Strings.TurnOnLocationView.messageText)
+            .font(Fonts.regularHeading1)
+            .foregroundColor(.aircastingGray)
+            .lineSpacing(10.0)
+    }
+    
+    var continueButton: some View {
+        Button(action: {
+            viewModel.onButtonClick()
+        }, label: {
+            Text(Strings.TurnOnLocationView.continueButton)
+        })
+        .frame(maxWidth: .infinity)
+        .buttonStyle(BlueButtonStyle())
+    }
+    
+    var locationPickerLink: some View {
+        NavigationLink(
+            destination: ChooseCustomLocationView(creatingSessionFlowContinues: $creatingSessionFlowContinues,
+                                                  sessionName: viewModel.getSessionName,
+                                                  baseURL: viewModel.passURLProvider),
+            isActive: $viewModel.isLocationSessionDetailsActive,
+            label: {
+                EmptyView()
+            }
+        )
+    }
+    
+    var createSesssionLink: some View {
+        NavigationLink(
+            destination: ConfirmCreatingSessionView(creatingSessionFlowContinues: $creatingSessionFlowContinues,
+                                                    baseURL: viewModel.passURLProvider,
+                                                    sessionName: viewModel.getSessionName),
+            isActive: $viewModel.isConfirmCreatingSessionActive,
+            label: {
+                EmptyView()
+            }
+        )
+    }
+}

--- a/AirCasting/CreateSessionViews/TurnOnLocationFixed/TurnOnLocationFixedViewModel.swift
+++ b/AirCasting/CreateSessionViews/TurnOnLocationFixed/TurnOnLocationFixedViewModel.swift
@@ -1,0 +1,46 @@
+// Created by Lunar on 27/01/2022.
+//
+import Foundation
+
+class TurnOnLocationFixedViewModel: ObservableObject {
+    
+    @Published var isConfirmCreatingSessionActive: Bool = false
+    @Published var isLocationSessionDetailsActive: Bool = false
+    @Published var alert: AlertInfo?
+    
+    private let locationHandler: LocationHandler
+    private let sessionContext: CreateSessionContext
+    private let urlProvider: BaseURLProvider
+    
+    var passURLProvider: BaseURLProvider {
+        return urlProvider
+    }
+    
+    var shouldShowAlert: Bool {
+        return locationHandler.isLocationDenied()
+    }
+    
+    var getSessionName: String {
+        return sessionContext.sessionName ?? ""
+    }
+    
+    init(locationHandler: LocationHandler, sessionContext: CreateSessionContext, urlProvider: BaseURLProvider) {
+        self.locationHandler = locationHandler
+        self.sessionContext = sessionContext
+        self.urlProvider = urlProvider
+    }
+    
+    func requestLocationAuthorisation() {
+        locationHandler.requestAuthorisation()
+    }
+    
+    func onButtonClick() {
+        switch shouldShowAlert {
+        case true:
+            alert = InAppAlerts.locationAlert()
+        case false:
+            isLocationSessionDetailsActive = !(sessionContext.isIndoor ?? true)
+            isConfirmCreatingSessionActive = sessionContext.isIndoor ?? true
+        }
+    }
+}

--- a/AirCasting/SDSync/ViewsFlow/BackendSyncCompleted/BackendSyncCompletedView.swift
+++ b/AirCasting/SDSync/ViewsFlow/BackendSyncCompleted/BackendSyncCompletedView.swift
@@ -69,7 +69,7 @@ private extension BackendSyncCompletedView {
 
     var BTNavigationLink: some View {
         NavigationLink(
-            destination: TurnOnBluetoothView(creatingSessionFlowContinues: $creatingSessionFlowContinues, sdSyncContinues: .constant(true), urlProvider: viewModel.urlProvider),
+            destination: TurnOnBluetoothView(creatingSessionFlowContinues: $creatingSessionFlowContinues, sdSyncContinues: .constant(true), locationHandler: DummyDefaultLocationHandler(), urlProvider: viewModel.urlProvider),
             isActive: .init(get: { viewModel.presentBTNextScreen }, set: { _ in }),
             label: {
                 EmptyView()

--- a/AirCasting/SDSync/ViewsFlow/SDRestartAB/SDRestartABView.swift
+++ b/AirCasting/SDSync/ViewsFlow/SDRestartAB/SDRestartABView.swift
@@ -60,7 +60,7 @@ extension SDRestartABView {
 
     var selectDeviceLink: some View {
         NavigationLink(
-            destination: SelectPeripheralView(SDClearingRouteProcess: viewModel.isSDClearProcess, creatingSessionFlowContinues: $creatingSessionFlowContinues, urlProvider: viewModel.urlProvider, syncMode: !viewModel.isSDClearProcess),
+            destination: SelectPeripheralView(SDClearingRouteProcess: viewModel.isSDClearProcess, creatingSessionFlowContinues: $creatingSessionFlowContinues, urlProvider: viewModel.urlProvider, locationHandler: DummyDefaultLocationHandler(), syncMode: !viewModel.isSDClearProcess),
             isActive: $viewModel.presentNextScreen,
             label: {
                 EmptyView()

--- a/AirCasting/Settings/SettingsView.swift
+++ b/AirCasting/Settings/SettingsView.swift
@@ -58,6 +58,7 @@ struct SettingsView: View {
                     TurnOnBluetoothView(creatingSessionFlowContinues: $BTScreenGo,
                                         sdSyncContinues: .constant(false),
                                         isSDClearProcess: SDClearingRouteProcess,
+                                        locationHandler: viewModel.locationHandler,
                                         urlProvider: urlProvider)
                 }
             }
@@ -91,7 +92,7 @@ struct SettingsView: View {
                                 TurnOnBluetoothView(creatingSessionFlowContinues: $BTScreenGo,
                                                     sdSyncContinues: .constant(false),
                                                     isSDClearProcess: SDClearingRouteProcess,
-                                                    urlProvider: urlProvider)
+                                                    locationHandler: viewModel.locationHandler, urlProvider: urlProvider)
                             }
                         }
                 })


### PR DESCRIPTION
The location screen which prompts the user to give the app access to the Location was moved to 'after SessionDetailsView' in the case when session is fixed. On the mobile it stays as it is.


https://trello.com/c/M3fRJ3wn/500-allow-users-to-create-fixed-session-even-if-they-have-location-tracking-disabled-but-keep-the-turn-on-location-view-as-a-reminde