### PR TITLE
Save session url on upload

### DIFF
--- a/AirCasting/CoreData/NSManagedObjectContext+Utils.swift
+++ b/AirCasting/CoreData/NSManagedObjectContext+Utils.swift
@@ -52,6 +52,7 @@ extension NSManagedObjectContext {
     // and we decided to use a NSManagedObjectID instead. Somehow it's not working right, but when I added
     // additional session-id constraint it started to behave somewhat properly. But this is a blind patch
     // and should be investigated and resolved.
+    // Issue: https://github.com/HabitatMap/AirCastingiOS/issues/579
     
     // Checks if stream exists, if not, creates a new one
     func newOrExisting<T: NSManagedObject>(streamID: MeasurementStreamID, for session: SessionUUID? = nil) throws -> T  {

--- a/AirCasting/CoreData/NSManagedObjectContext+Utils.swift
+++ b/AirCasting/CoreData/NSManagedObjectContext+Utils.swift
@@ -39,9 +39,21 @@ extension NSManagedObjectContext {
         return new
     }
     
-    // Checks if stream exists, if not, creates a new one
+    
     #warning("This seems odd and is also working odd. I don't think this is correct implementation")
-    // NOTE: I added session id as an optional parameter to fix my scenario, but this is a patch
+    // Explaination:
+    // I'm not sure why is that happening, but the fetch inside this function is returning multiple streams
+    // not associated with a single session. It causes the calling code to sometimes modify an incorrect
+    // stream object. I found this when implementing the url saving feature after uploads
+    // (https://github.com/HabitatMap/AirCastingiOS/pull/578) - I used the `Databse`s
+    // `func insertOrUpdateSessions(_ sessions: [Database.Session], completion: ((Error?) -> Void)?)`
+    // to achieve session URL update and it started acting weird - adding streams to existing dB sessions
+    // etc.. I think the root of the problem is that session streams don't have a unique identifiers
+    // and we decided to use a NSManagedObjectID instead. Somehow it's not working right, but when I added
+    // additional session-id constraint it started to behave somewhat properly. But this is a blind patch
+    // and should be investigated and resolved.
+    
+    // Checks if stream exists, if not, creates a new one
     func newOrExisting<T: NSManagedObject>(streamID: MeasurementStreamID, for session: SessionUUID? = nil) throws -> T  {
         let className = NSStringFromClass(T.classForCoder())
         let fetchRequest = NSFetchRequest<T>(entityName: className)

--- a/AirCasting/CoreData/NSManagedObjectContext+Utils.swift
+++ b/AirCasting/CoreData/NSManagedObjectContext+Utils.swift
@@ -40,10 +40,17 @@ extension NSManagedObjectContext {
     }
     
     // Checks if stream exists, if not, creates a new one
-    func newOrExisting<T: NSManagedObject>(streamID: MeasurementStreamID) throws -> T  {
+    #warning("This seems odd and is also working odd. I don't think this is correct implementation")
+    // NOTE: I added session id as an optional parameter to fix my scenario, but this is a patch
+    func newOrExisting<T: NSManagedObject>(streamID: MeasurementStreamID, for session: SessionUUID? = nil) throws -> T  {
         let className = NSStringFromClass(T.classForCoder())
         let fetchRequest = NSFetchRequest<T>(entityName: className)
         fetchRequest.predicate = NSPredicate(format: "id == \(streamID)")
+        if let session = session {
+            fetchRequest.predicate = NSCompoundPredicate(type: .and,
+                                                         subpredicates: [fetchRequest.predicate!,
+                                                                         NSPredicate(format: "session.uuid == %@", session.rawValue)])
+        }
         
         let results = try self.fetch(fetchRequest)
         if let existing  = results.first { return existing }

--- a/AirCasting/CoreData/PersistenceController+Database.swift
+++ b/AirCasting/CoreData/PersistenceController+Database.swift
@@ -59,7 +59,7 @@ extension PersistenceController: SessionInsertable {
                     try $0.measurementStreams?.forEach {
                         let streamEntity: MeasurementStreamEntity
                         if let id = $0.id {
-                            streamEntity = try context.newOrExisting(streamID: id)
+                            streamEntity = try context.newOrExisting(streamID: id, for: sessionEntity.uuid)
                         } else {
                             streamEntity = MeasurementStreamEntity(context: context)
                         }

--- a/AirCasting/CoreData/Session.swift
+++ b/AirCasting/CoreData/Session.swift
@@ -146,7 +146,7 @@ public enum DeviceType: Int, CustomStringConvertible {
 }
 
 extension Session {
-    func withUrlLocation(_ newLocation) -> Self {
+    func withUrlLocation(_ newLocation: String) -> Self {
         .init(uuid: uuid,
               type: type,
               name: name,

--- a/AirCasting/CoreData/Session.swift
+++ b/AirCasting/CoreData/Session.swift
@@ -144,3 +144,26 @@ public enum DeviceType: Int, CustomStringConvertible {
         }
     }
 }
+
+extension Session {
+    func withUrlLocation(_ newLocation) -> Self {
+        .init(uuid: uuid,
+              type: type,
+              name: name,
+              deviceType: deviceType,
+              location: location,
+              startTime: startTime,
+              contribute: contribute,
+              locationless: locationless,
+              deviceId: deviceId,
+              endTime: endTime,
+              followedAt: followedAt,
+              gotDeleted: gotDeleted,
+              isIndoor: isIndoor,
+              tags: tags,
+              urlLocation: newLocation,
+              version: version,
+              measurementStreams: measurementStreams,
+              status: status)
+    }
+}

--- a/AirCasting/Models/AirBeamCellularSessionCreator.swift
+++ b/AirCasting/Models/AirBeamCellularSessionCreator.swift
@@ -72,7 +72,8 @@ final class AirBeamCellularSessionCreator: SessionCreator {
                                                                 case .success(let output):
                                                                     measurementStreamStorage.accessStorage { storage in
                                                                         do {
-                                                                            try storage.createSession(session)
+                                                                            let sessionWithURL = session.withUrlLocation(output.location)
+                                                                            try storage.createSession(sessionWithURL)
                                                                             try AirBeam3Configurator(userAuthenticationSession: userAuthenticationSession,
                                                                                                      peripheral: peripheral).configureFixedCellularSession(uuid: sessionUUID,
                                                                                                                                                            location: sessionContext.startingLocation ?? CLLocationCoordinate2D(latitude: 200, longitude: 200),

--- a/AirCasting/Models/AirBeamFixedWifiSessionCreator.swift
+++ b/AirCasting/Models/AirBeamFixedWifiSessionCreator.swift
@@ -77,7 +77,8 @@ final class AirBeamFixedWifiSessionCreator: SessionCreator {
                                                                 case .success(let output):
                                                                     measurementStreamStorage.accessStorage { storage in
                                                                         do {
-                                                                            try storage.createSession(session)
+                                                                            let sessionWithURL = session.withUrlLocation(output.location)
+                                                                            try storage.createSession(sessionWithURL)
                                                                             try AirBeam3Configurator(userAuthenticationSession: userAuthenticationSession,
                                                                                                      peripheral: peripheral).configureFixedWifiSession(
                                                                                                         uuid: sessionUUID,

--- a/AirCasting/SessionsSynchronization/Adapters/Services/SessionUploadService.swift
+++ b/AirCasting/SessionsSynchronization/Adapters/Services/SessionUploadService.swift
@@ -21,6 +21,8 @@ final class SessionUploadService: SessionUpstream {
         return encoder
     }()
     
+    private let decoder = JSONDecoder()
+    
     private struct APICallData: Encodable {
         let session: String
         let compression: Bool
@@ -33,7 +35,7 @@ final class SessionUploadService: SessionUpstream {
         self.urlProvider = urlProvider
     }
     
-    func upload(session: SessionsSynchronization.SessionUpstreamData) -> Future<Void, Error> {
+    func upload(session: SessionsSynchronization.SessionUpstreamData) -> Future<SessionsSynchronization.SessionUpstreamResult, Error> {
         .init { [self, client, authorization, encoder, responseValidator] promise in
             let url = urlProvider.baseAppURL.appendingPathComponent("api/sessions")
             var request = URLRequest(url: url)
@@ -59,9 +61,10 @@ final class SessionUploadService: SessionUpstream {
             }
             client.requestTask(for: request) { result, request in
                 promise(
-                    result.tryMap { result -> Void in
+                    result.tryMap { result -> SessionsSynchronization.SessionUpstreamResult in
                         try responseValidator.validate(response: result.response, data: result.data)
-                        return ()
+                        let response = try decoder.decode(SessionsSynchronization.SessionUpstreamResult.self, from: result.data)
+                        return response
                     }
                 )
             }

--- a/AirCasting/SessionsSynchronization/Controller/Interfaces/SessionSynchronizationStore.swift
+++ b/AirCasting/SessionsSynchronization/Controller/Interfaces/SessionSynchronizationStore.swift
@@ -5,17 +5,24 @@ import Foundation
 import Combine
 import CoreLocation
 
+enum SessionSynchronizationStoreError: Error {
+    case noSessionsForUUID(uuid: SessionUUID)
+}
+
 /// Defines interface for objects which provide local store for sessions sync
 ///
 /// Overview of the sync process:
 /// 1. Fetch sessions stored locally on a device
 /// 2. Diff them against global database
-/// 3. Download/Upload/Delete accordingly (this interface)
+/// 3. Download/Upload/Delete accordingly
 protocol SessionSynchronizationStore {
     func getLocalSessionList() -> AnyPublisher<[SessionsSynchronization.Metadata], Error>
     
     @discardableResult
     func addSessions(with: [SessionsSynchronization.SessionStoreSessionData]) -> Future<Void, Error>
+    
+    @discardableResult
+    func saveURLForSession(uuid: SessionUUID, url: String) -> Future<Void, Error>
     
     @discardableResult
     func removeSessions(with: [SessionUUID]) -> Future<Void, Error>

--- a/AirCasting/SessionsSynchronization/Controller/Interfaces/SessionUpstream.swift
+++ b/AirCasting/SessionsSynchronization/Controller/Interfaces/SessionUpstream.swift
@@ -11,7 +11,7 @@ import Combine
 /// 2. Diff them against upstream database
 /// 3. Download/Upload/Delete accordingly (this interface)
 protocol SessionUpstream {
-    func upload(session: SessionsSynchronization.SessionUpstreamData) -> Future<Void, Error>
+    func upload(session: SessionsSynchronization.SessionUpstreamData) -> Future<SessionsSynchronization.SessionUpstreamResult, Error>
 }
 
 // MARK: Data structures
@@ -32,6 +32,10 @@ extension SessionsSynchronization {
         let latitude: Double?
         let longitude: Double?
         let deleted: Bool
+    }
+    
+    struct SessionUpstreamResult: Equatable, Codable {
+        let location: String
     }
     
     struct MeasurementStreamUpstreamData: Equatable, Codable {

--- a/AirCasting/SessionsSynchronization/Controller/SessionSynchronizationController.swift
+++ b/AirCasting/SessionsSynchronization/Controller/SessionSynchronizationController.swift
@@ -163,6 +163,7 @@ final class SessionSynchronizationController: SessionSynchronizer {
                     .upload(session: uploadData)
                     .onError({ _ in self.errorStream?.handleSyncError(.uploadFailure(uploadData.uuid)) })
                     .filterError(self.isConnectionError(_:))
+                    .map { _ in Void() }
                     .logError(message: "[SYNC] Uploading session failed")
             }
             .eraseToAnyPublisher()

--- a/AirCastingTests/API/SyncContextServiceTests.swift
+++ b/AirCastingTests/API/SyncContextServiceTests.swift
@@ -17,7 +17,8 @@ final class SyncContextServiceTests: XCTestCase {
     private let client = APIClientMock()
     private let auth = RequestAuthorizationServiceMock()
     private let responseValidator = HTTPResponseValidatorMock()
-    private lazy var service = SessionSynchronizationService(client: client, authorization: auth, responseValidator: responseValidator)
+    private let urlProvider = URLProviderMock(baseAppURL: URL(string: "http://aircasting.org/")!)
+    private lazy var service = SessionSynchronizationService(client: client, authorization: auth, responseValidator: responseValidator, urlProvider: urlProvider)
     private var cancellables: [AnyCancellable] = []
     
     override func tearDown() {
@@ -138,6 +139,14 @@ class HTTPResponseValidatorMock: HTTPResponseValidator {
     
     func validate(response: URLResponse, data: Data) throws {
         if let error = stubError { throw error }
+    }
+}
+
+class URLProviderMock: BaseURLProvider {
+    var baseAppURL: URL
+    
+    init(baseAppURL: URL) {
+        self.baseAppURL = baseAppURL
     }
 }
 

--- a/AirCastingTests/API/SyncDownstreamServiceTests.swift
+++ b/AirCastingTests/API/SyncDownstreamServiceTests.swift
@@ -9,7 +9,8 @@ final class SyncDownstreamServiceTests: XCTestCase {
     private let client = APIClientMock()
     private let auth = RequestAuthorizationServiceMock()
     private let responseValidator = HTTPResponseValidatorMock()
-    private lazy var service = SessionDownloadService(client: client, authorization: auth, responseValidator: responseValidator)
+    private let urlProvider = URLProviderMock(baseAppURL: URL(string: "http://aircasting.org/")!)
+    private lazy var service = SessionDownloadService(client: client, authorization: auth, responseValidator: responseValidator, urlProvider: urlProvider)
     private var cancellables: [AnyCancellable] = []
     
     override func tearDown() {
@@ -25,7 +26,7 @@ final class SyncDownstreamServiceTests: XCTestCase {
         
         XCTAssertEqual(self.client.callHistory.count, 1)
         let request = self.client.callHistory.first!
-        XCTAssertEqual(request.url?.absoluteString, "http://aircasting.org/api/user/sessions/empty.json?uuid=\(sessionUUID.rawValue)")
+        XCTAssertEqual(request.url?.absoluteString, "http://aircasting.org/api/user/sessions/update_session.json?uuid=\(sessionUUID.rawValue)")
         XCTAssertEqual(request.httpMethod, "GET")
         XCTAssertEqual(request.allHTTPHeaderFields?["Accept"], "application/json")
     }

--- a/AirCastingTests/ForgotPasswordTests/ForgotPasswordTest.swift
+++ b/AirCastingTests/ForgotPasswordTests/ForgotPasswordTest.swift
@@ -21,7 +21,7 @@ class ForgotPasswordViewModelTest: XCTestCase {
     
     func test_varsConformsToStringsStruct() {
         XCTAssertEqual(defaultForgotPasswordViewModel.title, Strings.ForgotPassword.title)
-        XCTAssertEqual(defaultForgotPasswordViewModel.actionTitle, Strings.ForgotPassword.actionTitle)
+        XCTAssertEqual(defaultForgotPasswordViewModel.actionTitle, Strings.Commons.ok)
         XCTAssertEqual(defaultForgotPasswordViewModel.emailInputTitle, Strings.ForgotPassword.emailInputTitle)
     }
 }

--- a/AirCastingTests/Logic/SessionsSynchronization/SynchronizationControllerTestHelpers.swift
+++ b/AirCastingTests/Logic/SessionsSynchronization/SynchronizationControllerTestHelpers.swift
@@ -196,7 +196,7 @@ extension SynchronizationControllerTests {
             if count == errorousUploadIndex {
                 self.uploadService.toReturn = .failure(DummyError())
             } else {
-                self.uploadService.toReturn = .success(())
+                self.uploadService.toReturn = .success(.init(location: "http://example.com/loc"))
             }
             if count == totalUploads { exp.fulfill() }
         }

--- a/AirCastingTests/Logic/SessionsSynchronization/SynchronizationControllerTestHelpers.swift
+++ b/AirCastingTests/Logic/SessionsSynchronization/SynchronizationControllerTestHelpers.swift
@@ -17,6 +17,21 @@ extension SynchronizationControllerTests {
         downloadService.toReturn = .success(download)
     }
     
+    func setupUploadWithStubbedSessionLocations(_ urlLocations: [String]) {
+        uploadService.toReturn = .success(.init(location: urlLocations[0]))
+        let uuidsToUpload = [SessionUUID](creating: .init(rawValue: UUID().uuidString)!, times: urlLocations.count)
+        let context = SessionsSynchronization.SynchronizationContext(needToBeDownloaded: [], needToBeUploaded: uuidsToUpload, removed: [])
+        remoteContextProvider.toReturn = .success(context)
+        var count: Int = 0
+        var sub: AnyCancellable?
+        sub = uploadService.$recordedHistory.sink { history in
+            guard history.count > 0 else { return }
+            guard count <= urlLocations.count else { sub?.cancel(); return }
+            self.uploadService.toReturn = .success(.init(location: urlLocations[count]))
+            count += 1
+        }
+    }
+    
     func setupWithStubbingStoreReads(_ stored: [SessionsSynchronization.SessionStoreSessionData]) {
         self.store.readSessionToReturn = stored[0]
         let uuidsToFetch = [SessionUUID?](creating: SessionUUID(rawValue: UUID().uuidString), times: stored.count).compactMap { $0 }
@@ -70,6 +85,14 @@ extension SynchronizationControllerTests {
             guard case .addSessions(_) = $0.last else { return false }
             return true
         }).last?.allWrittenData ?? []
+    }
+    
+    func spyStoreURLUpdates(count: Int = 1) -> [String] {
+        spyOnPublisher(store.$recordedHistory, count: count, filter: {
+            guard $0.count > 0 else { return false }
+            guard case .saveURLForSession(_) = $0.last else { return false }
+            return true
+        }).last?.allUpdatedURLs.map(\.url) ?? []
     }
     
     func spyStoreRemove(count: Int = 1) -> [SessionUUID] {

--- a/AirCastingTests/Logic/SessionsSynchronization/SynchronizationControllerTests.swift
+++ b/AirCastingTests/Logic/SessionsSynchronization/SynchronizationControllerTests.swift
@@ -128,6 +128,13 @@ final class SynchronizationControllerTests: XCTestCase {
         assertContainsSameElements(removedSessions, sessionsToDelete)
     }
     
+    func test_whenSessionIsUploaded_savesURLLocationToDatabase() {
+        let urlsToReturn = ["A", "B"]
+        setupUploadWithStubbedSessionLocations(urlsToReturn)
+        let savedURLs = spyStoreURLUpdates(count: urlsToReturn.count)
+        assertContainsSameElements(urlsToReturn, savedURLs)
+    }
+    
     // MARK: - Error handling
     
     func test_whenErrorFetchingLocalData_itDoesNotProcessFuther() {

--- a/AirCastingTests/Logic/SessionsSynchronization/SynchronizationTestDoubles.swift
+++ b/AirCastingTests/Logic/SessionsSynchronization/SynchronizationTestDoubles.swift
@@ -56,14 +56,20 @@ class UploadServiceMock: SessionUpstream {
 
 class SessionStoreMock: SessionSynchronizationStore {
     enum HistoryItem: Equatable {
+        struct SaveURLArgs: Equatable {
+            let uuid: SessionUUID
+            let url: String
+        }
         case getLocalSessions
         case addSessions([SessionsSynchronization.SessionStoreSessionData])
+        case saveURLForSession(SaveURLArgs)
         case removeSessions([SessionUUID])
         case readSession(SessionUUID)
     }
     
     @Published private(set) var recordedHistory: [HistoryItem] = []
     var writeErrorToReturn: Error? = nil
+    var saveURLErrorToReturn: Error? = nil
     var readErrorToReturn: Error? = nil
     var deleteErrorToReturn: Error? = nil
     
@@ -81,6 +87,13 @@ class SessionStoreMock: SessionSynchronizationStore {
         recordedHistory.append(.addSessions(sessions))
         return .init {
             $0(self.writeErrorToReturn == nil ? .success(()) : .failure(self.writeErrorToReturn!))
+        }
+    }
+    
+    func saveURLForSession(uuid: SessionUUID, url: String) -> Future<Void, Error> {
+        recordedHistory.append(.saveURLForSession(.init(uuid: uuid, url: url)))
+        return .init {
+            $0(self.saveURLErrorToReturn == nil ? .success(()) : .failure(self.saveURLErrorToReturn!))
         }
     }
     

--- a/AirCastingTests/Logic/SessionsSynchronization/SynchronizationTestDoubles.swift
+++ b/AirCastingTests/Logic/SessionsSynchronization/SynchronizationTestDoubles.swift
@@ -41,15 +41,15 @@ class DownloadServiceMock: SessionDownstream {
 }
 
 class UploadServiceMock: SessionUpstream {
-    var toReturn: Result<Void, Error>?
+    var toReturn: Result<SessionsSynchronization.SessionUpstreamResult, Error>?
     @Published var recordedHistory: [SessionsSynchronization.SessionUpstreamData] = []
     
     var allUploadedUUIDs: [SessionUUID] { recordedHistory.map(\.uuid) }
     
-    func upload(session: SessionsSynchronization.SessionUpstreamData) -> Future<Void, Error> {
+    func upload(session: SessionsSynchronization.SessionUpstreamData) -> Future<SessionsSynchronization.SessionUpstreamResult, Error> {
         recordedHistory.append(session)
         return .init { promise in
-            promise(self.toReturn ?? .success(()))
+            promise(self.toReturn ?? .success(.init(location: "http://example.com/loc")))
         }
     }
 }

--- a/AirCastingTests/Logic/SessionsSynchronization/SynchronizationTestMocks.swift
+++ b/AirCastingTests/Logic/SessionsSynchronization/SynchronizationTestMocks.swift
@@ -123,6 +123,7 @@ extension Array where Element == SessionStoreMock.HistoryItem {
     var allReads: [Element] { filter { if case .readSession(_) = $0 { return true }; return false } }
     var allWrites: [Element] { filter { if case .addSessions(_) = $0 { return true }; return false } }
     var allDeletes: [Element] { filter { if case .removeSessions(_) = $0 { return true }; return false } }
+    var allURLUpdates: [Element] { filter { if case .saveURLForSession(_) = $0 { return true }; return false } }
     
     var allWrittenData: [SessionsSynchronization.SessionStoreSessionData] {
         allWrites.map { write -> [SessionsSynchronization.SessionStoreSessionData]? in
@@ -142,6 +143,13 @@ extension Array where Element == SessionStoreMock.HistoryItem {
         }
         .compactMap { $0 }
         .flatMap { $0 }
+    }
+    
+    var allUpdatedURLs: [SessionStoreMock.HistoryItem.SaveURLArgs] {
+        allURLUpdates.compactMap { item -> SessionStoreMock.HistoryItem.SaveURLArgs? in
+            guard case .saveURLForSession(let args) = item else { return nil }
+            return args
+        }
     }
 }
 

--- a/AirCastingTests/Logic/SessionsSynchronization/SynchronizationTestMocks.swift
+++ b/AirCastingTests/Logic/SessionsSynchronization/SynchronizationTestMocks.swift
@@ -27,7 +27,8 @@ extension SessionsSynchronization.SessionDownstreamData {
               version: .default,
               streams: .default,
               location: .default,
-              isIndoor: .default)
+              isIndoor: .default,
+              notes: [])
     }
 }
 
@@ -68,7 +69,8 @@ extension SessionsSynchronization.SessionStoreSessionData {
                                                                                       longitude: 50.12)
                                                                                ])
               ],
-              deleted: false)
+              deleted: false,
+              notes: [])
     }
 }
 


### PR DESCRIPTION
# What was done
URLs received as a server response for uploaded sessions are now properly saved in the database

Trello: https://trello.com/c/3ti2pNwF