### PR TITLE
Logic for requesting location changed.

### DIFF
--- a/AirCasting.xcodeproj/project.pbxproj
+++ b/AirCasting.xcodeproj/project.pbxproj
@@ -342,6 +342,7 @@
 		DDBA6139276B3AE200E3FEF9 /* EditNoteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDBA6138276B3AE200E3FEF9 /* EditNoteView.swift */; };
 		DDBC156426A0799300982526 /* SystemSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDBC156326A0799300982526 /* SystemSettings.swift */; };
 		DDBC992626A1652A00B0662E /* ForgotPasswordTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDBC992526A1652A00B0662E /* ForgotPasswordTest.swift */; };
+		DDC22C8027B6C508000E81D1 /* ViewControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC22C7F27B6C508000E81D1 /* ViewControl.swift */; };
 		DDC3E954275E4C3A0066A5DF /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC3E953275E4C3A0066A5DF /* SettingsViewModel.swift */; };
 		DDC5F5882719694800F1F9D8 /* ShadowImages.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC5F5872719694800F1F9D8 /* ShadowImages.swift */; };
 		DDC5F58A271979F100F1F9D8 /* Fonts.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC5F589271979F100F1F9D8 /* Fonts.swift */; };
@@ -731,6 +732,7 @@
 		DDBA6138276B3AE200E3FEF9 /* EditNoteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditNoteView.swift; sourceTree = "<group>"; };
 		DDBC156326A0799300982526 /* SystemSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemSettings.swift; sourceTree = "<group>"; };
 		DDBC992526A1652A00B0662E /* ForgotPasswordTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForgotPasswordTest.swift; sourceTree = "<group>"; };
+		DDC22C7F27B6C508000E81D1 /* ViewControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControl.swift; sourceTree = "<group>"; };
 		DDC3E953275E4C3A0066A5DF /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		DDC5F5872719694800F1F9D8 /* ShadowImages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowImages.swift; sourceTree = "<group>"; };
 		DDC5F589271979F100F1F9D8 /* Fonts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fonts.swift; sourceTree = "<group>"; };
@@ -1443,6 +1445,7 @@
 				3397C81E2787024C0050B333 /* UserDefaults.swift */,
 				3375E8D32791EDC50019A5DE /* CLLocationCoordinate2D.swift */,
 				DD9EBFD7279EEAB300192CB5 /* DataBuilder.swift */,
+				DDC22C7F27B6C508000E81D1 /* ViewControl.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2487,6 +2490,7 @@
 				DD8A36A426C3CE7900C26725 /* ChooseCustomLocationView.swift in Sources */,
 				AC524A9A2615E3600061AD45 /* NSManagedObjectContext+Utils.swift in Sources */,
 				B38E6CCA26C5F19F00C21C45 /* SessionStoppable.swift in Sources */,
+				DDC22C8027B6C508000E81D1 /* ViewControl.swift in Sources */,
 				B3EBB10C26A06D2D002BD81F /* DefaultForgotPasswordViewModel.swift in Sources */,
 				DDB448282732AA4B00F11340 /* AirCastingGraphSimplifier.swift in Sources */,
 				AC6D567F25AC54A400D221BA /* ChartView.swift in Sources */,

--- a/AirCasting/CreateSessionViews/TurnOnLocation/TurnOnLocationView.swift
+++ b/AirCasting/CreateSessionViews/TurnOnLocation/TurnOnLocationView.swift
@@ -35,6 +35,13 @@ struct TurnOnLocationView: View {
         .onChange(of: viewModel.shouldShowAlert) { newValue in
             if newValue { viewModel.alert = InAppAlerts.locationAlert() }
         }
+        .onAppCameToForeground {
+            // The aim of this is to allow user to choose location option from native Apple location popup
+            // It is the case when the user first nedded to turn on system location services at all.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                viewModel.requestLocationAuthorisation()
+            }
+        }
     }
     
     var titleLabel: some View {
@@ -54,7 +61,7 @@ struct TurnOnLocationView: View {
         Button(action: {
             viewModel.onButtonClick()
         }, label: {
-            Text(Strings.TurnOnLocationView.continueButton)
+            Text(Strings.Commons.continue)
         })
         .frame(maxWidth: .infinity)
         .buttonStyle(BlueButtonStyle())

--- a/AirCasting/CreateSessionViews/TurnOnLocationFixed/TurnOnLocationFixedView.swift
+++ b/AirCasting/CreateSessionViews/TurnOnLocationFixed/TurnOnLocationFixedView.swift
@@ -18,21 +18,26 @@ struct TurnOnLocationFixedView: View {
                 titleLabel
                 messageLabel
             }
-            continueButton
+            VStack(spacing: 20) {
+                turnOnButton
+                continueButton
+            }
         }
         .padding()
         .alert(item: $viewModel.alert, content: { $0.makeAlert() })
-        .background(
-            Group {
-                locationPickerLink
-                createSesssionLink
-            }
-        )
+        .background(locationPickerLink)
         .onAppear {
             viewModel.requestLocationAuthorisation()
         }
         .onChange(of: viewModel.shouldShowAlert) { newValue in
             if newValue { viewModel.alert = InAppAlerts.locationAlert() }
+        }
+        .onAppCameToForeground {
+            // The aim of this is to allow user to choose location option from native Apple location popup
+            // It is the case when the user first nedded to turn on system location services at all.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                viewModel.requestLocationAuthorisation()
+            }
         }
     }
     
@@ -49,11 +54,21 @@ struct TurnOnLocationFixedView: View {
             .lineSpacing(10.0)
     }
     
-    var continueButton: some View {
+    var turnOnButton: some View {
         Button(action: {
             viewModel.onButtonClick()
         }, label: {
             Text(Strings.TurnOnLocationView.continueButton)
+        })
+        .frame(maxWidth: .infinity)
+        .buttonStyle(BlueButtonStyle())
+    }
+    
+    var continueButton: some View {
+        Button(action: {
+            viewModel.onContinueButtonClick()
+        }, label: {
+            Text(Strings.Commons.continue)
         })
         .frame(maxWidth: .infinity)
         .buttonStyle(BlueButtonStyle())
@@ -64,17 +79,6 @@ struct TurnOnLocationFixedView: View {
             destination: ChooseCustomLocationView(creatingSessionFlowContinues: $creatingSessionFlowContinues,
                                                   sessionName: viewModel.getSessionName),
             isActive: $viewModel.isLocationSessionDetailsActive,
-            label: {
-                EmptyView()
-            }
-        )
-    }
-    
-    var createSesssionLink: some View {
-        NavigationLink(
-            destination: ConfirmCreatingSessionView(creatingSessionFlowContinues: $creatingSessionFlowContinues,
-                                                    sessionName: viewModel.getSessionName),
-            isActive: $viewModel.isConfirmCreatingSessionActive,
             label: {
                 EmptyView()
             }

--- a/AirCasting/CreateSessionViews/TurnOnLocationFixed/TurnOnLocationFixedView.swift
+++ b/AirCasting/CreateSessionViews/TurnOnLocationFixed/TurnOnLocationFixedView.swift
@@ -56,7 +56,7 @@ struct TurnOnLocationFixedView: View {
     
     var turnOnButton: some View {
         Button(action: {
-            viewModel.onButtonClick()
+            viewModel.onTurnOnButtonClicked()
         }, label: {
             Text(Strings.TurnOnLocationView.continueButton)
         })

--- a/AirCasting/CreateSessionViews/TurnOnLocationFixed/TurnOnLocationFixedViewModel.swift
+++ b/AirCasting/CreateSessionViews/TurnOnLocationFixed/TurnOnLocationFixedViewModel.swift
@@ -32,7 +32,7 @@ class TurnOnLocationFixedViewModel: ObservableObject {
         isLocationSessionDetailsActive = true
     }
     
-    func onButtonClick() {
+    func onTurnOnButtonClicked() {
         switch shouldShowAlert {
         case true:
             alert = InAppAlerts.locationAlert()

--- a/AirCasting/CreateSessionViews/TurnOnLocationFixed/TurnOnLocationFixedViewModel.swift
+++ b/AirCasting/CreateSessionViews/TurnOnLocationFixed/TurnOnLocationFixedViewModel.swift
@@ -5,7 +5,6 @@ import Resolver
 
 class TurnOnLocationFixedViewModel: ObservableObject {
     
-    @Published var isConfirmCreatingSessionActive: Bool = false
     @Published var isLocationSessionDetailsActive: Bool = false
     @Published var alert: AlertInfo?
     
@@ -29,13 +28,16 @@ class TurnOnLocationFixedViewModel: ObservableObject {
         locationHandler.requestAuthorisation()
     }
     
+    func onContinueButtonClick() {
+        isLocationSessionDetailsActive = true
+    }
+    
     func onButtonClick() {
         switch shouldShowAlert {
         case true:
             alert = InAppAlerts.locationAlert()
         case false:
-            isLocationSessionDetailsActive = !(sessionContext.isIndoor ?? true)
-            isConfirmCreatingSessionActive = sessionContext.isIndoor ?? true
+            isLocationSessionDetailsActive = true
         }
     }
 }

--- a/AirCasting/Extensions/ViewControl.swift
+++ b/AirCasting/Extensions/ViewControl.swift
@@ -1,0 +1,18 @@
+// Created by Lunar on 11/02/2022.
+//
+
+import SwiftUI
+
+extension View {
+    func onAppCameToForeground(perform action: @escaping () -> Void) -> some View {
+        self.onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
+            action()
+        }
+    }
+
+    func onAppWentToBackground(perform action: @escaping () -> Void) -> some View {
+        self.onReceive(NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification)) { _ in
+            action()
+        }
+    }
+}


### PR DESCRIPTION
Discussed on the call:
Now when session if fixed and indoor the location screen is skipped. When session is fixed and outdoor, the location screen is shown as a reminder and an option for the user. The only requirement is to allow location when doing mobile session without disabled mapping. In this commit, we are handling a special case where users could have location services turned off at all and never get an Apple popup about location.

https://trello.com/c/M7Jk012v/529-mobile-fixed-wizard-location-services-off-cant-continue-through-wizard