### PR TITLE
Add missing background task end marking code when invalidated by the system

### DIFF
--- a/AirCasting/SessionsSynchronization/Controller/Utils/ScheduledSessionSynchronizerProxy.swift
+++ b/AirCasting/SessionsSynchronization/Controller/Utils/ScheduledSessionSynchronizerProxy.swift
@@ -36,8 +36,12 @@ final class ScheduledSessionSynchronizerProxy<S: Scheduler>: SessionSynchronizer
     func triggerSynchronization(options: SessionSynchronizationOptions, completion: (() -> Void)?) {
         scheduler.schedule { [weak self] in
             guard let self = self else { return }
-            self.backgroundTaskIdentifier = UIApplication.shared.beginBackgroundTask(withName: "Session synchronization") {
-                self.controller.stopSynchronization()
+            self.backgroundTaskIdentifier = UIApplication.shared.beginBackgroundTask(withName: "Session synchronization") { [weak self] in
+                Log.info("Background task expired, stopping synchronization")
+                self?.controller.stopSynchronization()
+                if let identifier  = self?.backgroundTaskIdentifier {
+                    UIApplication.shared.endBackgroundTask(identifier)
+                }
             }
             self.controller.triggerSynchronization(options: options) { [ weak self] in
                 if let identifier  = self?.backgroundTaskIdentifier {


### PR DESCRIPTION
## What was done?

The code that handles background tasks for session sync might have caused some crashes in background