### PR TITLE
Fix crashes for background context

### DIFF
--- a/AirCasting/CoreData/MeasurementStreamStorage.swift
+++ b/AirCasting/CoreData/MeasurementStreamStorage.swift
@@ -230,11 +230,7 @@ final class HiddenCoreDataMeasurementStreamStorage: MeasurementStreamStorageCont
             threshold.thresholdHigh = stream.thresholdHigh
             threshold.thresholdVeryHigh = stream.thresholdVeryHigh
         }
-        // Save here is important so that NSManagedObjectID is not temporary.
-        try context.save()
-
-        try context.obtainPermanentIDs(for: [newStream])
-
+        
         return newStream.localID
     }
 


### PR DESCRIPTION
This PR fixes the app crash that was happening when user entered background after creating new mobile AB session before the app received first measurements.