### PR TITLE
Get only followed sessions in DownloadMeasurementsService

### DIFF
--- a/AirCasting/CoreData/MeasurementStreamStorage.swift
+++ b/AirCasting/CoreData/MeasurementStreamStorage.swift
@@ -278,6 +278,9 @@ final class HiddenCoreDataMeasurementStreamStorage: MeasurementStreamStorageCont
                 sessionEntity.followedAt = DateBuilder.getFakeUTCDate()
             } else {
                 sessionEntity.followedAt = nil
+                if let ui = sessionEntity.userInterface {
+                    context.delete(ui)
+                }
             }
             try context.save()
         } catch {

--- a/AirCasting/CoreData/MeasurementStreamStorage.swift
+++ b/AirCasting/CoreData/MeasurementStreamStorage.swift
@@ -253,6 +253,11 @@ final class HiddenCoreDataMeasurementStreamStorage: MeasurementStreamStorageCont
 
         try context.save()
     }
+    
+    func updateSessionEndTimeWithoutUTCConversion(_ endTime: Date, for sessionUUID: SessionUUID) throws {
+        let sessionEntity = try context.existingSession(uuid: sessionUUID)
+        sessionEntity.endTime = endTime
+    }
 
     func updateSessionNameAndTags(name: String, tags: String, for sessionUUID: SessionUUID) throws {
         let sessionEntity = try context.existingSession(uuid: sessionUUID)

--- a/AirCasting/Models/SessionExtension.swift
+++ b/AirCasting/Models/SessionExtension.swift
@@ -15,7 +15,7 @@ extension SessionEntity {
     var isDormant: Bool { type == .mobile && status == .FINISHED }
     var isFixed: Bool { type == .fixed }
     var isFollowed: Bool { followedAt != nil }
-    var isFixedNotFollowed: Bool { type == .fixed && followedAt == nil }
+    var isUnfollowedFixed: Bool { type == .fixed && followedAt == nil }
     var isInStandaloneMode: Bool { isMobile && status == .DISCONNECTED && deviceType == .AIRBEAM3 }
     var deletable: Bool { isDormant || isFixed }
     var editable: Bool { isDormant || isFixed }

--- a/AirCasting/Models/SessionExtension.swift
+++ b/AirCasting/Models/SessionExtension.swift
@@ -15,6 +15,7 @@ extension SessionEntity {
     var isDormant: Bool { type == .mobile && status == .FINISHED }
     var isFixed: Bool { type == .fixed }
     var isFollowed: Bool { followedAt != nil }
+    var isFixedNotFollowed: Bool { type == .fixed && followedAt == nil }
     var isInStandaloneMode: Bool { isMobile && status == .DISCONNECTED && deviceType == .AIRBEAM3 }
     var deletable: Bool { isDormant || isFixed }
     var editable: Bool { isDormant || isFixed }

--- a/AirCasting/Services/DownloadMeasurmentsService.swift
+++ b/AirCasting/Services/DownloadMeasurmentsService.swift
@@ -52,7 +52,7 @@ final class DownloadMeasurementsService: MeasurementUpdatingService {
     
     private func getAllSessionsData(completion: @escaping ([(uuid: SessionUUID, lastSynced: Date)]) -> Void) {
         let request: NSFetchRequest<SessionEntity> = SessionEntity.fetchRequest()
-        request.predicate = request.typePredicate(.fixed)
+        request.predicate = NSPredicate(format: "followedAt != NULL")
         let context = persistenceController.editContext
         var returnData: [(uuid: SessionUUID, lastSynced: Date)] = []
         context.perform { [unowned self] in

--- a/AirCasting/SessionViews/ABMeasurementsView.swift
+++ b/AirCasting/SessionViews/ABMeasurementsView.swift
@@ -97,8 +97,8 @@ struct _ABMeasurementsView: View {
                 }
             }
         }
-        .onChange(of: isCollapsed, perform: { new in
-            if isCollapsed == false && (!hasAnyMeasurements || (session.isFixed && !session.isFollowed)) {
+        .onChange(of: isCollapsed, perform: { _ in
+            if isCollapsed == false && (!hasAnyMeasurements || session.isFixedNotFollowed) {
                 measurementsViewModel.syncMeasurements()
             }
         })

--- a/AirCasting/SessionViews/ABMeasurementsView.swift
+++ b/AirCasting/SessionViews/ABMeasurementsView.swift
@@ -45,10 +45,12 @@ struct _ABMeasurementsView: View {
         return session.sortedStreams ?? []
     }
     
+    private var hasAnyMeasurements: Bool {
+        (session.sortedStreams ?? []).filter { $0.latestValue != nil }.count > 0
+    }
+    
     var body: some View {
-        let hasAnyMeasurements = streamsToShow.filter { $0.latestValue != nil }.count > 0
-        
-        return Group {
+        Group {
             if hasAnyMeasurements {
                 VStack(alignment: .leading, spacing: 5) {
                     measurementsTitle
@@ -96,7 +98,7 @@ struct _ABMeasurementsView: View {
             }
         }
         .onChange(of: isCollapsed, perform: { new in
-            if isCollapsed == false && !hasAnyMeasurements {
+            if isCollapsed == false && (!hasAnyMeasurements || (session.isFixed && !session.isFollowed)) {
                 measurementsViewModel.syncMeasurements()
             }
         })

--- a/AirCasting/SessionViews/ABMeasurementsView.swift
+++ b/AirCasting/SessionViews/ABMeasurementsView.swift
@@ -98,7 +98,7 @@ struct _ABMeasurementsView: View {
             }
         }
         .onChange(of: isCollapsed, perform: { _ in
-            if isCollapsed == false && (!hasAnyMeasurements || session.isFixedNotFollowed) {
+            if isCollapsed == false && (!hasAnyMeasurements || session.isUnfollowedFixed) {
                 measurementsViewModel.syncMeasurements()
             }
         })

--- a/AirCasting/SessionViews/SessionCardView.swift
+++ b/AirCasting/SessionViews/SessionCardView.swift
@@ -132,7 +132,7 @@ private extension SessionCardView {
             action: {
                 withAnimation {
                     isCollapsed.toggle()
-                    if !session.isFixedNotFollowed {
+                    if !session.isUnfollowedFixed {
                         uiState.toggleCardExpanded(sessionUUID: session.uuid)
                     }
                 }

--- a/AirCasting/SessionViews/SessionCardView.swift
+++ b/AirCasting/SessionViews/SessionCardView.swift
@@ -132,7 +132,9 @@ private extension SessionCardView {
             action: {
                 withAnimation {
                     isCollapsed.toggle()
-                    uiState.toggleCardExpanded(sessionUUID: session.uuid)
+                    if !(session.isFixed && !session.isFollowed) {
+                        uiState.toggleCardExpanded(sessionUUID: session.uuid)
+                    }
                 }
             },
             isExpandButtonNeeded: true,

--- a/AirCasting/SessionViews/SessionCardView.swift
+++ b/AirCasting/SessionViews/SessionCardView.swift
@@ -132,7 +132,7 @@ private extension SessionCardView {
             action: {
                 withAnimation {
                     isCollapsed.toggle()
-                    if !(session.isFixed && !session.isFollowed) {
+                    if !session.isFixedNotFollowed {
                         uiState.toggleCardExpanded(sessionUUID: session.uuid)
                     }
                 }

--- a/AirCasting/SessionViews/SessionCartViewModel/DefaultSyncingMeasurementsViewModel.swift
+++ b/AirCasting/SessionViews/SessionCartViewModel/DefaultSyncingMeasurementsViewModel.swift
@@ -37,14 +37,19 @@ final class DefaultSyncingMeasurementsViewModel: SyncingMeasurementsViewModel, O
                 let dataBaseStreams = data.streams.values.map { value in
                     SynchronizationDataConverter().convertDownloadDataToDatabaseStream(data: value)
                 }
-                
                 let sessionId = self.session.uuid!
                 let sessionName = self.session.name
                 
                 // TODO: Move all this logic to a service/controller
                 // https://github.com/HabitatMap/AirCastingiOS/issues/606
                 measurementStreamStorage.accessStorage { storage in
-                    
+                    if let endTime = data.endTime {
+                        do {
+                            try storage.updateSessionEndTimeWithoutUTCConversion(endTime, for: data.uuid)
+                        } catch {
+                            Log.error("Failed to save new session end time: \(error)")
+                        }
+                    }
                     dataBaseStreams.forEach { stream in
                         Log.info("Downloaded \(stream.measurements.count) measurements for \(stream.sensorName)")
                         let sensorName = stream.sensorName

--- a/AirCasting/SessionsSynchronization/Adapters/Services/SessionDownloadService.swift
+++ b/AirCasting/SessionsSynchronization/Adapters/Services/SessionDownloadService.swift
@@ -97,9 +97,7 @@ final class SessionDownloadService: SessionDownstream, MeasurementsDownloadable 
                 do {
                     try responseValidator.validate(response: response.response, data: response.data)
                     let sessionData = try decoder.decode(SessionsSynchronization.SessionDownstreamData.self, from: response.data)
-                                        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(2)) {
                     completion(.success(sessionData))
-                                         }
                 } catch {
                     completion(.failure(error))
                 }


### PR DESCRIPTION
I think it will improve performance a lot. Currently we are downloading measurements for all of the fixed sessions and for each of those sessions we are triggering call to api and then updating session params in core data. I think it is probably not necessary to do it for sessions which are not followed.

## Code changes
* limit periodic measurements download to followed sessions only
* download new measurements for followed sessions on card expand
* remove saving cardToggle state for fixed not followed sessions

Additional improvements:
* remove 2 seconds wait before calling completion in session downloader (it was causing the long waiting for measurements download and I think most likely it was not necessary - should be tested to check if it didn't break anything important)