### PR TITLE
Return completion success when there are no fixed sessions to upload

### DIFF
--- a/AirCasting/ABConnector/SDSyncController.swift
+++ b/AirCasting/ABConnector/SDSyncController.swift
@@ -153,7 +153,7 @@ class SDSyncController {
             case .success():
                 completion(true)
             case .failure(let error):
-                Log.error(error.localizedDescription)
+                Log.error("Failed to clear SD card: \(error.localizedDescription)")
                 completion(false)
             }
         }

--- a/AirCasting/SDSync/FixedSessions/SDCardFixedSessionsSavingService.swift
+++ b/AirCasting/SDSync/FixedSessions/SDCardFixedSessionsSavingService.swift
@@ -81,6 +81,11 @@ class SDCardFixedSessionsUploadingService {
         var tasksCompleted = 0
         var allSuccess = true
         
+        guard !uploadParams.isEmpty else {
+            completion(true)
+            return
+        }
+        
         uploadParams.forEach { params in
             apiService.uploadFixedSession(input: params) { result in
                 tasksCompleted += 1


### PR DESCRIPTION
I found and solve a small bug. The sd sync wasn't completing when there were no fixed sessions to be uploaded,