### PR TITLE
Fix deleting and editing notes and deleting streams

### DIFF
--- a/AirCasting/CoreData/MeasurementStreamStorage.swift
+++ b/AirCasting/CoreData/MeasurementStreamStorage.swift
@@ -346,20 +346,20 @@ final class HiddenCoreDataMeasurementStreamStorage: MeasurementStreamStorageCont
         noteEntity.date = note.date
         noteEntity.number = Int64(note.number)
         sessionEntity.addToNotes(noteEntity)
-        try context.save()
     }
 
     func updateNote(_ note: Note, newText: String, for sessionUUID: SessionUUID) throws {
         let sessionEntity = try context.existingSession(uuid: sessionUUID)
-        let note = (sessionEntity.notes?.first(where: { ($0 as! NoteEntity).number == note.number }) as! NoteEntity)
-        note.text = newText
-        try context.save()
+        if let note = (sessionEntity.notes?.first(where: { ($0 as! NoteEntity).number == note.number }) as? NoteEntity) {
+            note.text = newText
+        }
     }
 
     func deleteNote(_ note: Note, for sessionUUID: SessionUUID) throws {
         let sessionEntity = try context.existingSession(uuid: sessionUUID)
-        let note = (sessionEntity.notes?.first(where: { ($0 as! NoteEntity).number == note.number }) as! NoteEntity)
-        context.delete(note)
+        if let note = (sessionEntity.notes?.first(where: { ($0 as! NoteEntity).number == note.number }) as? NoteEntity) {
+            context.delete(note)
+        }
     }
 
     func getNotes(for sessionUUID: SessionUUID) throws -> [Note] {

--- a/AirCasting/Map/GoogleMapView.swift
+++ b/AirCasting/Map/GoogleMapView.swift
@@ -284,8 +284,10 @@ struct GoogleMapView: UIViewRepresentable {
         }
         
         func mapView(_ mapView: GMSMapView, didTap marker: GMSMarker) -> Bool {
-            parent.noteNumber = marker.userData as! Int
-            parent.noteMarketTapped = true
+            if let userData = marker.userData as? Int {
+                parent.noteNumber = userData
+                parent.noteMarketTapped = true
+            }
             return true
         }
         

--- a/AirCasting/Notes/NotesHandler.swift
+++ b/AirCasting/Notes/NotesHandler.swift
@@ -63,7 +63,7 @@ class NotesHandlerDefault: NSObject, NotesHandler, NSFetchedResultsControllerDel
         measurementStreamStorage.accessStorage { [self] storage in
             do {
                 try storage.deleteNote(note, for: sessionUUID)
-                fetchSession { session in
+                fetchSession(storage: storage) { session in
                     self.sessionUpdateService.updateSession(session: session) { result in
                         switch result {
                         case .success(let updateData):
@@ -72,6 +72,7 @@ class NotesHandlerDefault: NSObject, NotesHandler, NSFetchedResultsControllerDel
                             completion()
                         case .failure(let error):
                             Log.info("Failed updating session while updating notes: \(error.localizedDescription)")
+                            completion()
                         }
                     }
                 }
@@ -85,7 +86,7 @@ class NotesHandlerDefault: NSObject, NotesHandler, NSFetchedResultsControllerDel
         measurementStreamStorage.accessStorage { [self] storage in
             do {
                 try storage.updateNote(note, newText: newText, for: sessionUUID)
-                fetchSession { session in
+                fetchSession(storage: storage) { session in
                     self.sessionUpdateService.updateSession(session: session) { result in
                         switch result {
                         case .success(let updateData):
@@ -94,6 +95,7 @@ class NotesHandlerDefault: NSObject, NotesHandler, NSFetchedResultsControllerDel
                             completion()
                         case .failure(let error):
                             Log.info("Failed updating session while updating notes: \(error.localizedDescription)")
+                            completion()
                         }
                     }
                 }
@@ -126,13 +128,11 @@ class NotesHandlerDefault: NSObject, NotesHandler, NSFetchedResultsControllerDel
 
 // MARK: Internal methods
 extension NotesHandlerDefault {
-    private func fetchSession(completion: @escaping (SessionEntity) -> Void) {
-        measurementStreamStorage.accessStorage { [self] storage in
-            do {
-                completion(try storage.getExistingSession(with: sessionUUID))
-            } catch {
-                Log.info("Error when fetching session: \(error)")
-            }
+    private func fetchSession(storage: HiddenCoreDataMeasurementStreamStorage,completion: @escaping (SessionEntity) -> Void) {
+        do {
+            completion(try storage.getExistingSession(with: sessionUUID))
+        } catch {
+            Log.info("Error when fetching session: \(error)")
         }
     }
 }

--- a/AirCasting/SessionViews/SessionCartViewModel/DefaultDeleteSessionViewModel.swift
+++ b/AirCasting/SessionViews/SessionCartViewModel/DefaultDeleteSessionViewModel.swift
@@ -103,6 +103,7 @@ class DefaultDeleteSessionViewModel: DeleteSessionViewModel {
                     try? storage.updateVersion(for: sessionToPass.uuid, to: updateData.version)
                 case .failure(let error):
                     Log.info("Failed updating session while deleting streams: \(error.localizedDescription)")
+                    try? storage.deleteStreams(session.uuid)
                 }
             }
         }

--- a/AirCasting/SingleSessionSynchronizer/SessionUpdateService.swift
+++ b/AirCasting/SingleSessionSynchronizer/SessionUpdateService.swift
@@ -51,12 +51,13 @@ class DefaultSessionUpdateService: SessionUpdateService {
         })
         
         session.notes?.forEach({ note in
-            let n = note as! NoteEntity
-            notes.append(CreateSessionApi.NotesParams(date: n.date ?? DateBuilder.getFakeUTCDate(),
-                                                      text: n.text ?? "",
-                                                      lat: n.lat,
-                                                      long: n.long,
-                                                      number: Int(n.number)))
+            if let n = note as? NoteEntity {
+                notes.append(CreateSessionApi.NotesParams(date: n.date ?? DateBuilder.getFakeUTCDate(),
+                                                          text: n.text ?? "",
+                                                          lat: n.lat,
+                                                          long: n.long,
+                                                          number: Int(n.number)))
+            }
         })
     
         let sessionToPass = CreateSessionApi.SessionParams(uuid: session.uuid,


### PR DESCRIPTION
This was broken by changes to updateSession implementation and it wasn't working if sessions wasn't present on backend. Now it is fixed.