### PR TITLE
Revert change of url used for downloading sessions during sync

### DIFF
--- a/AirCasting/SessionsSynchronization/Adapters/Services/SessionDownloadService.swift
+++ b/AirCasting/SessionsSynchronization/Adapters/Services/SessionDownloadService.swift
@@ -39,7 +39,7 @@ final class SessionDownloadService: SessionDownstream, MeasurementsDownloadable 
     }
     
     private func download(session: SessionUUID, completion: @escaping (Result<SessionsSynchronization.SessionDownstreamData, Error>) -> Void) -> Cancellable {
-        let urlComponentPart = urlProvider.baseAppURL.appendingPathComponent("api/user/sessions/update_session.json")
+        let urlComponentPart = urlProvider.baseAppURL.appendingPathComponent("api/user/sessions/empty.json")
         var urlComponents = URLComponents(string: urlComponentPart.absoluteString)!
         urlComponents.queryItems = [
             URLQueryItem(name: "uuid", value: session.rawValue)


### PR DESCRIPTION
The URL was changed in [previous PR](https://github.com/HabitatMap/AirCastingiOS/commit/b7e52c40e30fcff032cd99a0aa044108108e017d#commitcomment-70392380) and it was probably by mistake, so we are changing it back.