### PR TITLE
Utf8 as an additional way of convertion.

### DIFF
--- a/AirCasting/ABConnector/HexMessagesBuilder.swift
+++ b/AirCasting/ABConnector/HexMessagesBuilder.swift
@@ -86,15 +86,16 @@ struct HexMessagesBuilder {
     
     func asciToHex(asciStr: String) -> String {
         var outputString = ""
+        var hex = ""
+        
         for character in asciStr {
             if let asci = character.asciiValue {
-                let hex = String(format: "%02hhx", asci)
-                outputString.append(hex)
+                hex = String(format: "%02hhx", asci)
             } else {
                 let data = Data(character.utf8)
-                let hex = data.map{ String(format:"%02hhx", $0) }.joined()
-                outputString.append(hex)
+                hex = data.map{ String(format:"%02hhx", $0) }.joined()
             }
+            outputString.append(hex)
         }
         return outputString
     }

--- a/AirCasting/ABConnector/HexMessagesBuilder.swift
+++ b/AirCasting/ABConnector/HexMessagesBuilder.swift
@@ -86,11 +86,15 @@ struct HexMessagesBuilder {
     
     func asciToHex(asciStr: String) -> String {
         var outputString = ""
-        
         for character in asciStr {
-            let asci = character.asciiValue
-            let hex = String(format: "%02hhx", asci!)
-            outputString.append(hex)
+            if let asci = character.asciiValue {
+                let hex = String(format: "%02hhx", asci)
+                outputString.append(hex)
+            } else {
+                let data = Data(character.utf8)
+                let hex = data.map{ String(format:"%02hhx", $0) }.joined()
+                outputString.append(hex)
+            }
         }
         return outputString
     }


### PR DESCRIPTION
Now, whenever you do have some kind of "Ś" or "Ę" in you wifi password or SSID the app will crash. The reason is that ASCII is not able to convert those characters. 
The purpose of this PR is to allow UTF8 converting when ASCII cannot. We want to stay with ASCII as it was working well most of the time. The second reason is UTF8 and ASCII is not the same all the time and Raymond advice not to use UTF8 for everything. 
I think that this is the safest approach for now and it does work as it should. My SSID has "Ś" and with this code everything goes well.

https://trello.com/c/8EDmXgpc/580-specials-characters-are-not-converted-to-ascii
https://trello.com/c/FNZjsdkv/610-hexmessagebuilder