### PR TITLE
Protect screen - only mobile.

### DIFF
--- a/AirCasting/AirCastingApp.swift
+++ b/AirCasting/AirCastingApp.swift
@@ -18,6 +18,8 @@ struct AirCastingApp: App {
     private let syncScheduler: SynchronizationScheduler
     @Injected private var sessionSynchronizer: SessionSynchronizer
     @Injected private var persistenceController: PersistenceController
+    @Injected private var mobilePeripheralSessionManager: MobilePeripheralSessionManager
+    @Injected private var microphoneManager: MicrophoneManager
     private let appBecameActive = PassthroughSubject<Void, Never>()
     @ObservedObject private var offlineMessageViewModel: OfflineMessageViewModel
     private var cancellables: [AnyCancellable] = []
@@ -39,11 +41,15 @@ struct AirCastingApp: App {
         }.onChange(of: scenePhase) { newScenePhase in
             switch newScenePhase {
             case .active:
-                shouldProtect = false
+                if mobilePeripheralSessionManager.isMobileSessionActive || microphoneManager.isRecording {
+                    shouldProtect = false
+                }
                 persistenceController.uiSuspended = false
                 appBecameActive.send()
             case .background, .inactive:
-                shouldProtect = true
+                if mobilePeripheralSessionManager.isMobileSessionActive || microphoneManager.isRecording {
+                    shouldProtect = true
+                }
                 persistenceController.uiSuspended = true
             @unknown default:
                 fatalError()

--- a/AirCasting/AirCastingApp.swift
+++ b/AirCasting/AirCastingApp.swift
@@ -41,9 +41,7 @@ struct AirCastingApp: App {
         }.onChange(of: scenePhase) { newScenePhase in
             switch newScenePhase {
             case .active:
-                if mobilePeripheralSessionManager.isMobileSessionActive || microphoneManager.isRecording {
-                    shouldProtect = false
-                }
+                shouldProtect = false
                 persistenceController.uiSuspended = false
                 appBecameActive.send()
             case .background, .inactive:

--- a/AirCasting/MobilePeripheralSessionManager.swift
+++ b/AirCasting/MobilePeripheralSessionManager.swift
@@ -6,6 +6,8 @@ import CoreBluetooth
 import CoreLocation
 
 class MobilePeripheralSessionManager {
+    var isMobileSessionActive: Bool { activeMobileSession != nil }
+
     private let measurementStreamStorage: MeasurementStreamStorage
     private lazy var locationProvider = LocationProvider()
 


### PR DESCRIPTION
Protect screen shows only when mobile session is on.

https://trello.com/c/UuRsghpc/607-consider-custom-app-switcher-screen-to-ensure-that-app-wont-be-terminated-during-recording-a-session -- comment