### PR TITLE
Fix location reload on S&F feature

### DIFF
--- a/AirCasting/SearchAndFollow/SearchAndFollowMap/MapSessionMarker.swift
+++ b/AirCasting/SearchAndFollow/SearchAndFollowMap/MapSessionMarker.swift
@@ -4,7 +4,11 @@
 import UIKit
 import CoreLocation
 
-struct MapSessionMarker {
+struct MapSessionMarker: Equatable {
+    static func == (lhs: MapSessionMarker, rhs: MapSessionMarker) -> Bool {
+        lhs.id == rhs.id
+    }
+    
     let id: Int
     let username: String
     let uuid: String

--- a/AirCasting/SearchAndFollow/SearchMap/SearchMapView.swift
+++ b/AirCasting/SearchAndFollow/SearchMap/SearchMapView.swift
@@ -59,9 +59,7 @@ struct SearchMapView: View {
                 result ? self.presentationMode.wrappedValue.dismiss() : nil
             })
             .alert(item: $viewModel.alert, content: { $0.makeAlert() })
-            .sheet(isPresented: $viewModel.isLocationPopupPresented, onDismiss: {
-                viewModel.locationPopupDisimssed()
-            }) {
+            .sheet(isPresented: $viewModel.isLocationPopupPresented) {
                 PlacePicker(service: SearchPickerService(addressName: .init(get: {
                     viewModel.passedLocation
                 }, set: { new in

--- a/AirCasting/SearchAndFollow/SearchMap/SearchMapViewModel.swift
+++ b/AirCasting/SearchAndFollow/SearchMap/SearchMapViewModel.swift
@@ -58,8 +58,6 @@ class SearchMapViewModel: ObservableObject {
         passedLocationAddress = newLocationAddress
     }
     
-    func locationPopupDisimssed() { redoTapped() }
-    
     func redoTapped() {
         guard let currentPosition = currentPosition else {
             Log.warning("Should never happen that current position is not present")
@@ -83,6 +81,7 @@ class SearchMapViewModel: ObservableObject {
         updateSessionList(geoSquare: geoSquare)
         searchAgainButton = false
         cardPointerID = .noValue
+        currentPosition = geoSquare
     }
     
     func markerSelectionChanged(using point: Int) {


### PR DESCRIPTION
Execute code only when needed, after map idle is detected. Deleted what was not needed for map and search reload implementation - dismissView function for modal sheet.

+ The code for reloading dots on the map and refreshing the views was executing many times, now it should be improved.

https://trello.com/c/czdkWCr0/642-sf-map-after-entering-new-location-map-pans-to-new-location-but-results-arent-updated