### PR TITLE
Changing keyboard type in ThresholdsSettingsView

### DIFF
--- a/AirCasting/Extensions/ViewControl.swift
+++ b/AirCasting/Extensions/ViewControl.swift
@@ -15,4 +15,9 @@ extension View {
             action()
         }
     }
+    
+    func hideKeyboard() {
+        let resign = #selector(UIResponder.resignFirstResponder)
+        UIApplication.shared.sendAction(resign, to: nil, from: nil, for: nil)
+    }
 }

--- a/AirCasting/SessionViews/ThresholdSettings/ThresholdsSettingsView.swift
+++ b/AirCasting/SessionViews/ThresholdSettings/ThresholdsSettingsView.swift
@@ -22,51 +22,114 @@ struct ThresholdsSettingsView: View {
     }
     
     var body: some View {
-        Form {
-            VStack(alignment: .leading, spacing: 16) {
-                Text(Strings.SessionCart.heatmapSettingsTitle)
-                    .foregroundColor(.darkBlue)
-                    .font(Fonts.heavyTitle1)
-                Text(Strings.SessionCart.heatmapSettingsdescription)
-                    .foregroundColor(.aircastingGray)
-                    .font(Fonts.regularHeading2)
-            }
-            .padding()
-            
-            Section {
-                veryHighTextfield
-                highTextfield
-                mediumTextfield
-                lowTextfield
-                veryLowTextfield
-            }
-            
-            VStack {
-                Button(action: {
-                    thresholdValues = thresholdSettingsViewModel.updateToNewThresholds()
-                    presentationMode.wrappedValue.dismiss()
-                })
-                {
-                    Text(Strings.SessionCart.saveChangesButton)
-                        .frame(maxWidth: .infinity)
+        if #available(iOS 15.0, *) {
+            Form {
+                VStack(alignment: .leading, spacing: 16) {
+                    Text(Strings.SessionCart.heatmapSettingsTitle)
+                        .foregroundColor(.darkBlue)
+                        .font(Fonts.heavyTitle1)
+                    Text(Strings.SessionCart.heatmapSettingsdescription)
+                        .foregroundColor(.aircastingGray)
+                        .font(Fonts.regularHeading2)
                 }
-                .buttonStyle(BlueButtonStyle())
+                .padding()
                 
-                Button(Strings.SessionCart.resetChangesButton, action: {
-                    thresholdValues = thresholdSettingsViewModel.resetToDefault()
-                    presentationMode.wrappedValue.dismiss()
-                })
+                Section {
+                    veryHighTextfield
+                    highTextfield
+                    mediumTextfield
+                    lowTextfield
+                    veryLowTextfield
+                }
+                .keyboardType(.numberPad)
+                
+                VStack {
+                    Button(action: {
+                        thresholdValues = thresholdSettingsViewModel.updateToNewThresholds()
+                        presentationMode.wrappedValue.dismiss()
+                    })
+                    {
+                        Text(Strings.SessionCart.saveChangesButton)
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(BlueButtonStyle())
+                    
+                    Button(Strings.SessionCart.resetChangesButton, action: {
+                        thresholdValues = thresholdSettingsViewModel.resetToDefault()
+                        presentationMode.wrappedValue.dismiss()
+                    })
                     .frame(minHeight: 35)
+                }
+                .listRowBackground(Color.clear)
+                .buttonStyle(BorderlessButtonStyle())
             }
-            .listRowBackground(Color.clear)
-            .buttonStyle(BorderlessButtonStyle())
-        }
-        .onAppear {
-            thresholdSettingsViewModel.thresholdVeryLow = string(thresholdValues.veryLow)
-            thresholdSettingsViewModel.thresholdLow = string(thresholdValues.low)
-            thresholdSettingsViewModel.thresholdMedium = string(thresholdValues.medium)
-            thresholdSettingsViewModel.thresholdHigh = string(thresholdValues.high)
-            thresholdSettingsViewModel.thresholdVeryHigh = string(thresholdValues.veryHigh)
+            .onAppear {
+                thresholdSettingsViewModel.thresholdVeryLow = string(thresholdValues.veryLow)
+                thresholdSettingsViewModel.thresholdLow = string(thresholdValues.low)
+                thresholdSettingsViewModel.thresholdMedium = string(thresholdValues.medium)
+                thresholdSettingsViewModel.thresholdHigh = string(thresholdValues.high)
+                thresholdSettingsViewModel.thresholdVeryHigh = string(thresholdValues.veryHigh)
+            }
+            .toolbar {
+                ToolbarItemGroup(placement: .keyboard) {
+                    Spacer()
+                    Button("Done") {
+                        hideKeyboard()
+                    }
+                }
+            }
+            
+        } else {
+            Form {
+                VStack(alignment: .leading, spacing: 16) {
+                    Text(Strings.SessionCart.heatmapSettingsTitle)
+                        .foregroundColor(.darkBlue)
+                        .font(Fonts.heavyTitle1)
+                    Text(Strings.SessionCart.heatmapSettingsdescription)
+                        .foregroundColor(.aircastingGray)
+                        .font(Fonts.regularHeading2)
+                }
+                .padding()
+                
+                Section {
+                    veryHighTextfield
+                    highTextfield
+                    mediumTextfield
+                    lowTextfield
+                    veryLowTextfield
+                }
+                .keyboardType(.numberPad)
+                
+                VStack {
+                    Button(action: {
+                        thresholdValues = thresholdSettingsViewModel.updateToNewThresholds()
+                        presentationMode.wrappedValue.dismiss()
+                    })
+                    {
+                        Text(Strings.SessionCart.saveChangesButton)
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(BlueButtonStyle())
+                    
+                    Button(Strings.SessionCart.resetChangesButton, action: {
+                        thresholdValues = thresholdSettingsViewModel.resetToDefault()
+                        presentationMode.wrappedValue.dismiss()
+                    })
+                    .frame(minHeight: 35)
+                }
+                .listRowBackground(Color.clear)
+                .buttonStyle(BorderlessButtonStyle())
+            }
+            .onAppear {
+                thresholdSettingsViewModel.thresholdVeryLow = string(thresholdValues.veryLow)
+                thresholdSettingsViewModel.thresholdLow = string(thresholdValues.low)
+                thresholdSettingsViewModel.thresholdMedium = string(thresholdValues.medium)
+                thresholdSettingsViewModel.thresholdHigh = string(thresholdValues.high)
+                thresholdSettingsViewModel.thresholdVeryHigh = string(thresholdValues.veryHigh)
+            }
+            .onTapGesture {
+                hideKeyboard()
+            }
         }
     }
                                                                  

--- a/AirCasting/SessionViews/ThresholdSettings/ThresholdsSettingsView.swift
+++ b/AirCasting/SessionViews/ThresholdSettings/ThresholdsSettingsView.swift
@@ -23,113 +23,16 @@ struct ThresholdsSettingsView: View {
     
     var body: some View {
         if #available(iOS 15.0, *) {
-            Form {
-                VStack(alignment: .leading, spacing: 16) {
-                    Text(Strings.SessionCart.heatmapSettingsTitle)
-                        .foregroundColor(.darkBlue)
-                        .font(Fonts.heavyTitle1)
-                    Text(Strings.SessionCart.heatmapSettingsdescription)
-                        .foregroundColor(.aircastingGray)
-                        .font(Fonts.regularHeading2)
-                }
-                .padding()
-                
-                Section {
-                    veryHighTextfield
-                    highTextfield
-                    mediumTextfield
-                    lowTextfield
-                    veryLowTextfield
-                }
-                .keyboardType(.numberPad)
-                
-                VStack {
-                    Button(action: {
-                        thresholdValues = thresholdSettingsViewModel.updateToNewThresholds()
-                        presentationMode.wrappedValue.dismiss()
-                    })
-                    {
-                        Text(Strings.SessionCart.saveChangesButton)
-                            .frame(maxWidth: .infinity)
-                    }
-                    .buttonStyle(BlueButtonStyle())
-                    
-                    Button(Strings.SessionCart.resetChangesButton, action: {
-                        thresholdValues = thresholdSettingsViewModel.resetToDefault()
-                        presentationMode.wrappedValue.dismiss()
-                    })
-                    .frame(minHeight: 35)
-                }
-                .listRowBackground(Color.clear)
-                .buttonStyle(BorderlessButtonStyle())
-            }
-            .onAppear {
-                thresholdSettingsViewModel.thresholdVeryLow = string(thresholdValues.veryLow)
-                thresholdSettingsViewModel.thresholdLow = string(thresholdValues.low)
-                thresholdSettingsViewModel.thresholdMedium = string(thresholdValues.medium)
-                thresholdSettingsViewModel.thresholdHigh = string(thresholdValues.high)
-                thresholdSettingsViewModel.thresholdVeryHigh = string(thresholdValues.veryHigh)
-            }
-            .toolbar {
-                ToolbarItemGroup(placement: .keyboard) {
-                    Spacer()
-                    Button("Done") {
-                        hideKeyboard()
+            mainBody
+                .toolbar {
+                    ToolbarItemGroup(placement: .keyboard) {
+                        Spacer()
+                        Button(Strings.SessionCart.keyboardToolbarDoneButton) { hideKeyboard() }
                     }
                 }
-            }
-            
         } else {
-            Form {
-                VStack(alignment: .leading, spacing: 16) {
-                    Text(Strings.SessionCart.heatmapSettingsTitle)
-                        .foregroundColor(.darkBlue)
-                        .font(Fonts.heavyTitle1)
-                    Text(Strings.SessionCart.heatmapSettingsdescription)
-                        .foregroundColor(.aircastingGray)
-                        .font(Fonts.regularHeading2)
-                }
-                .padding()
-                
-                Section {
-                    veryHighTextfield
-                    highTextfield
-                    mediumTextfield
-                    lowTextfield
-                    veryLowTextfield
-                }
-                .keyboardType(.numberPad)
-                
-                VStack {
-                    Button(action: {
-                        thresholdValues = thresholdSettingsViewModel.updateToNewThresholds()
-                        presentationMode.wrappedValue.dismiss()
-                    })
-                    {
-                        Text(Strings.SessionCart.saveChangesButton)
-                            .frame(maxWidth: .infinity)
-                    }
-                    .buttonStyle(BlueButtonStyle())
-                    
-                    Button(Strings.SessionCart.resetChangesButton, action: {
-                        thresholdValues = thresholdSettingsViewModel.resetToDefault()
-                        presentationMode.wrappedValue.dismiss()
-                    })
-                    .frame(minHeight: 35)
-                }
-                .listRowBackground(Color.clear)
-                .buttonStyle(BorderlessButtonStyle())
-            }
-            .onAppear {
-                thresholdSettingsViewModel.thresholdVeryLow = string(thresholdValues.veryLow)
-                thresholdSettingsViewModel.thresholdLow = string(thresholdValues.low)
-                thresholdSettingsViewModel.thresholdMedium = string(thresholdValues.medium)
-                thresholdSettingsViewModel.thresholdHigh = string(thresholdValues.high)
-                thresholdSettingsViewModel.thresholdVeryHigh = string(thresholdValues.veryHigh)
-            }
-            .onTapGesture {
-                hideKeyboard()
-            }
+            mainBody
+                .onTapGesture { hideKeyboard() }
         }
     }
                                                                  
@@ -178,6 +81,56 @@ struct ThresholdsSettingsView: View {
         HStack {
             showDescriptionLabel(text: Strings.Thresholds.veryLow)
             showThresholdTextfield(value: $thresholdSettingsViewModel.thresholdVeryLow)
+        }
+    }
+    
+    var mainBody: some View {
+        Form {
+            VStack(alignment: .leading, spacing: 16) {
+                Text(Strings.SessionCart.heatmapSettingsTitle)
+                    .foregroundColor(.darkBlue)
+                    .font(Fonts.heavyTitle1)
+                Text(Strings.SessionCart.heatmapSettingsdescription)
+                    .foregroundColor(.aircastingGray)
+                    .font(Fonts.regularHeading2)
+            }
+            .padding()
+            
+            Section {
+                veryHighTextfield
+                highTextfield
+                mediumTextfield
+                lowTextfield
+                veryLowTextfield
+            }
+            .keyboardType(.numberPad)
+            
+            VStack {
+                Button(action: {
+                    thresholdValues = thresholdSettingsViewModel.updateToNewThresholds()
+                    presentationMode.wrappedValue.dismiss()
+                })
+                {
+                    Text(Strings.SessionCart.saveChangesButton)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(BlueButtonStyle())
+                
+                Button(Strings.SessionCart.resetChangesButton, action: {
+                    thresholdValues = thresholdSettingsViewModel.resetToDefault()
+                    presentationMode.wrappedValue.dismiss()
+                })
+                .frame(minHeight: 35)
+            }
+            .listRowBackground(Color.clear)
+            .buttonStyle(BorderlessButtonStyle())
+            .onAppear {
+                thresholdSettingsViewModel.thresholdVeryLow = string(thresholdValues.veryLow)
+                thresholdSettingsViewModel.thresholdLow = string(thresholdValues.low)
+                thresholdSettingsViewModel.thresholdMedium = string(thresholdValues.medium)
+                thresholdSettingsViewModel.thresholdHigh = string(thresholdValues.high)
+                thresholdSettingsViewModel.thresholdVeryHigh = string(thresholdValues.veryHigh)
+            }
         }
     }
 }

--- a/AirCasting/Utils/Strings.swift
+++ b/AirCasting/Utils/Strings.swift
@@ -242,6 +242,7 @@ struct Strings {
                                                               comment: "")
         static let lastMinuteMeasurement: String = NSLocalizedString("Last minute measurement",
                                                                      comment: "")
+        static let keyboardToolbarDoneButton: String = NSLocalizedString("Done", comment: "")
     }
     
     enum Thresholds {


### PR DESCRIPTION
https://trello.com/c/4qBI79YP/650-changing-keyboard-type-in-thresholds-settings-view

Two ways of handling the keyboard because the toolbar for the keyboard is available only for iOS 15.0 and higher. So for iOS > 15 users will tap "Done" to dismiss the keyboard as per the attached screenshot. Whereas for iOS versions lower than 15 the user will tap anywhere to dismiss the keyboard.

![screenshot](https://user-images.githubusercontent.com/82096200/167823349-664f001c-f5e6-45da-8156-9aa19ed07a1a.png)
