### PR TITLE
Fix autoupdating data for followed sessions

### DIFF
--- a/AirCasting/APICommunicator/FixedSession.swift
+++ b/AirCasting/APICommunicator/FixedSession.swift
@@ -83,10 +83,9 @@ final class FixedSessionAPIService {
             URLQueryItem(name: "uuid", value: uuid.rawValue),
             URLQueryItem(name: "last_measurement_sync", value: syncDateStr)
         ]
-        let urlWithParams = components.url!
-
+        
         // Build URLRequest
-        var request = URLRequest.jsonGET(url: url)
+        var request = URLRequest.jsonGET(url: components.url!)
         do {
             try authorisationService.authorise(request: &request)
             return apiClient.requestTask(for: request) { [responseValidator, decoder] result, _ in

--- a/AirCasting/SDSync/FixedSessions/SyncedMeasurementsDownloadingService.swift
+++ b/AirCasting/SDSync/FixedSessions/SyncedMeasurementsDownloadingService.swift
@@ -18,7 +18,7 @@ struct SyncedMeasurementsDownloadingService: SyncedMeasurementsDownloader {
         prepareSessionsData(sessionsUUIDs) { sessionsData in
             sessionsData.forEach { session in
                 measurementsDownloadingService.downloadMeasurements(for: session.uuid, lastSynced: session.lastSynced) {
-                    //TODO: this is probably just temporary. Let's figure out how they do it in android
+                    // TODO: this is probably just temporary. Let's figure out how they do it in android
                     removeDoubledMeasurements(session.uuid)
                 }
             }


### PR DESCRIPTION
https://trello.com/c/BoXuTSwl/651-170-2-following-card-timestamps-charts-not-refreshing-on-view-nor-on-pull-down

https://trello.com/c/YyY6cgEL/652-170-2-fixed-card-timestamps-lmms-not-updating-on-expand