### PR TITLE
Fix adding indoor argument when creating cellular sessions

### DIFF
--- a/AirCasting/Models/AirBeamCellularSessionCreator.swift
+++ b/AirCasting/Models/AirBeamCellularSessionCreator.swift
@@ -19,7 +19,8 @@ final class AirBeamCellularSessionCreator: SessionCreator {
     
     func createSession(_ sessionContext: CreateSessionContext, completion: @escaping (Result<Void, Error>) -> Void) {
         guard let sessionType = sessionContext.sessionType,
-              let sessionUUID = sessionContext.sessionUUID else {
+              let sessionUUID = sessionContext.sessionUUID,
+              let isIndoor = sessionContext.isIndoor else {
             assertionFailure("invalidCreateSessionContext \(sessionContext)")
             completion(.failure(AirBeamSessionCreatorError.invalidCreateSessionContext(sessionContext)))
             return
@@ -32,6 +33,7 @@ final class AirBeamCellularSessionCreator: SessionCreator {
                               location: sessionContext.startingLocation,
                               startTime: DateBuilder.getFakeUTCDate(),
                               followedAt: DateBuilder.getFakeUTCDate(),
+                              isIndoor: isIndoor,
                               tags: sessionContext.sessionTags)
         
         // if session is fixed: create an empty session on server,
@@ -39,8 +41,7 @@ final class AirBeamCellularSessionCreator: SessionCreator {
         guard let name = session.name,
               let startTime = session.startTime,
               let peripheral = sessionContext.peripheral,
-              let contribute = sessionContext.contribute,
-              let isIndoor = sessionContext.isIndoor else {
+              let contribute = sessionContext.contribute else {
             assertionFailure("invalidCreateSessionContext \(sessionContext)")
             completion(.failure(AirBeamSessionCreatorError.invalidCreateSessionContext(sessionContext)))
             return


### PR DESCRIPTION
There was a small bug for creating indoor cellular sessions. We were not passing this argument when creating a session struct and it was set to false by default. This PR fixes that.