### PR TITLE
Progress View improved - SD Sync flow

### DIFF
--- a/AirCasting.xcodeproj/project.pbxproj
+++ b/AirCasting.xcodeproj/project.pbxproj
@@ -1634,14 +1634,13 @@
 		ACCEB2012763A2230040140B /* ViewsFlow */ = {
 			isa = PBXGroup;
 			children = (
+				ACCEB2082763A2230040140B /* SDSyncRootView */,
+				ACCEB2102763A2230040140B /* BackendSyncCompleted */,
+				ACCEB2162763A2230040140B /* SDSyncUnplugAB */,
+				ACCEB20D2763A2230040140B /* SDRestartAB */,
+				ACCEB2132763A2230040140B /* SDSyncingAB */,
 				ACCEB2022763A2230040140B /* SDSyncComplete */,
 				ACCEB2052763A2230040140B /* ClearingSDCard */,
-				ACCEB2082763A2230040140B /* SDSyncRootView */,
-				ACCEB20B2763A2230040140B /* SDSyncSuccess */,
-				ACCEB20D2763A2230040140B /* SDRestartAB */,
-				ACCEB2102763A2230040140B /* BackendSyncCompleted */,
-				ACCEB2132763A2230040140B /* SDSyncingAB */,
-				ACCEB2162763A2230040140B /* SDSyncUnplugAB */,
 			);
 			path = ViewsFlow;
 			sourceTree = "<group>";
@@ -1671,13 +1670,6 @@
 				ACCEB20A2763A2230040140B /* SDSyncRootView.swift */,
 			);
 			path = SDSyncRootView;
-			sourceTree = "<group>";
-		};
-		ACCEB20B2763A2230040140B /* SDSyncSuccess */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = SDSyncSuccess;
 			sourceTree = "<group>";
 		};
 		ACCEB20D2763A2230040140B /* SDRestartAB */ = {

--- a/AirCasting/CreateSessionViews/SelectPeripheralView.swift
+++ b/AirCasting/CreateSessionViews/SelectPeripheralView.swift
@@ -17,12 +17,12 @@ struct SelectPeripheralView: View {
     @EnvironmentObject var sessionContext: CreateSessionContext
     @Injected private var connectionController: AirBeamConnectionController
     @Binding var creatingSessionFlowContinues: Bool
-    var syncMode: Bool? = false
+    var syncMode: Bool = false
     
     var body: some View {
         GeometryReader { geometry in
             VStack(spacing: 30) {
-                ProgressView(value: syncMode! ? 0.710 : 0.375)
+                ProgressView(value: syncMode ? 0.710 : 0.375)
                 titleLabel
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 25) {

--- a/AirCasting/CreateSessionViews/SelectPeripheralView.swift
+++ b/AirCasting/CreateSessionViews/SelectPeripheralView.swift
@@ -22,7 +22,7 @@ struct SelectPeripheralView: View {
     var body: some View {
         GeometryReader { geometry in
             VStack(spacing: 30) {
-                ProgressView(value: 0.375)
+                ProgressView(value: syncMode! ? 0.710 : 0.375)
                 titleLabel
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 25) {

--- a/AirCasting/CreateSessionViews/TurnOnBluetoothView.swift
+++ b/AirCasting/CreateSessionViews/TurnOnBluetoothView.swift
@@ -22,7 +22,7 @@ struct TurnOnBluetoothView: View {
 
     var body: some View {
         VStack(spacing: 50) {
-            ProgressView(value: 0.125)
+            ProgressView(value: sdSyncContinues ? 0.355 : 0.125)
             Image("1-bluetooth")
                 .resizable()
                 .scaledToFit()

--- a/AirCasting/SDSync/ViewsFlow/BackendSyncCompleted/BackendSyncCompletedView.swift
+++ b/AirCasting/SDSync/ViewsFlow/BackendSyncCompleted/BackendSyncCompletedView.swift
@@ -10,7 +10,7 @@ struct BackendSyncCompletedView<VM: BackendSyncCompletedViewModel>: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 40) {
-            ProgressView(value: 0.2)
+            ProgressView(value: 0.284)
             Spacer()
             HStack() {
                 Spacer()

--- a/AirCasting/SDSync/ViewsFlow/SDRestartAB/SDRestartABView.swift
+++ b/AirCasting/SDSync/ViewsFlow/SDRestartAB/SDRestartABView.swift
@@ -15,7 +15,7 @@ struct SDRestartABView: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 40) {
-            ProgressView(value: 0.3)
+            ProgressView(value: 0.568)
             Spacer()
             HStack() {
                 Spacer()

--- a/AirCasting/SDSync/ViewsFlow/SDSyncComplete/SDSyncCompleteView.swift
+++ b/AirCasting/SDSync/ViewsFlow/SDSyncComplete/SDSyncCompleteView.swift
@@ -12,7 +12,7 @@ struct SDSyncCompleteView<VM: SDSyncCompleteViewModel>: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 40) {
-            ProgressView(value: 0.9)
+            ProgressView(value: 0.994)
             Spacer()
             HStack() {
                 Spacer()

--- a/AirCasting/SDSync/ViewsFlow/SDSyncRootView/SDSyncRootView.swift
+++ b/AirCasting/SDSync/ViewsFlow/SDSyncRootView/SDSyncRootView.swift
@@ -10,7 +10,7 @@ struct SDSyncRootView: View {
     
     var body: some View {
         VStack(spacing: 40) {
-            ProgressView(value: 0.1)
+            ProgressView(value: 0.142)
             Spacer()
             ZStack(alignment: Alignment(horizontal: .trailing, vertical: .bottom), content: {
                 syncImage

--- a/AirCasting/SDSync/ViewsFlow/SDSyncUnplugAB/UnplugABView.swift
+++ b/AirCasting/SDSync/ViewsFlow/SDSyncUnplugAB/UnplugABView.swift
@@ -15,7 +15,7 @@ struct UnplugABView: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 40) {
-            ProgressView(value: 0.3)
+            ProgressView(value: 0.426)
             Spacer()
             HStack() {
                 Spacer()

--- a/AirCasting/SDSync/ViewsFlow/SDSyncingAB/SyncingABView.swift
+++ b/AirCasting/SDSync/ViewsFlow/SDSyncingAB/SyncingABView.swift
@@ -16,7 +16,7 @@ struct SyncingABView<VM: SDSyncViewModel>: View {
 
     var body: some View {
         VStack(spacing: 40) {
-            ProgressView(value: 0.7)
+            ProgressView(value: 0.852)
             Spacer()
             ZStack(alignment: Alignment(horizontal: .trailing, vertical: .bottom), content: {
                 syncingImage


### PR DESCRIPTION
Progress View inside the AB sync flows equally divided to look well visually.

**Where:**
This PR only covers the ProgressBar inside the `Sync data from AB`.

**What:**
ProgressBar is divided into 7 parts. The value corresponding to each screen was assigned to it.

https://trello.com/c/CJ4oNJ95/728-improved-progressbar-sync-data-from-ab