### PR TITLE
Setting section which allows to switch between 12/24 hour format.

### DIFF
--- a/AirCasting/AuthViews/UserSettings.swift
+++ b/AirCasting/AuthViews/UserSettings.swift
@@ -13,6 +13,7 @@ class UserSettings: ObservableObject {
     @Injected private var featureFlagProvider: FeatureFlagProvider
     private let convertToCelsiusKey = Constants.UserDefaultsKeys.convertToCelsius
     private let satteliteMapKey = Constants.UserDefaultsKeys.satelliteMapKey
+    private let twentyFourHourFormatKey = Constants.UserDefaultsKeys.twentyFourHoursFormatKey
 
     var contributingToCrowdMap: Bool {
         get {
@@ -68,6 +69,17 @@ class UserSettings: ObservableObject {
             objectWillChange.send()
         }
     }
+    
+    var twentyFourHour: Bool {
+        get {
+            userDefaults.bool(forKey: twentyFourHourFormatKey)
+        }
+        set {
+            userDefaults.setValue(newValue, forKey: twentyFourHourFormatKey)
+            Log.info("Changed twenty four hour format to \(twentyFourHour ? "ON" : "OFF")")
+            objectWillChange.send()
+        }
+    }
 
     init(userDefaults: UserDefaults = .standard) {
         self.userDefaults = userDefaults
@@ -78,5 +90,6 @@ class UserSettings: ObservableObject {
         disableMapping = isFeatureFlagOn ? userDefaults.bool(forKey: locationlessKey) : false
         convertToCelsius = userDefaults.bool(forKey: convertToCelsiusKey)
         satteliteMap = userDefaults.bool(forKey: satteliteMapKey)
+        twentyFourHour = userDefaults.valueExists(forKey: twentyFourHourFormatKey) ? userDefaults.bool(forKey: twentyFourHourFormatKey) : true
     }
 }

--- a/AirCasting/Dashboard/Reordering/ReorderingSessionHeader.swift
+++ b/AirCasting/Dashboard/Reordering/ReorderingSessionHeader.swift
@@ -2,8 +2,10 @@
 //
 
 import SwiftUI
+import Resolver
 
 struct ReorderingSessionHeader: View {
+    @InjectedObject private var userSettings: UserSettings
     var session: Sessionable
     
     var body: some View {
@@ -49,7 +51,10 @@ private extension ReorderingSessionHeader {
     }
 
     func adaptTimeAndDate() -> Text {
-        let formatter = DateFormatters.SessionCartView.utcDateIntervalFormatter
+        var formatter: DateIntervalFormatter {
+            if userSettings.twentyFourHour { return DateFormatters.SessionCardView.utcDateIntervalFormatter }
+            return DateFormatters.SessionCardView.utcDateInterval12hFormatter
+        }
         
         guard let start = session.startTime else { return Text("") }
         let end = session.endTime ?? DateBuilder.getFakeUTCDate()

--- a/AirCasting/Dashboard/Reordering/ReorderingSessionHeader.swift
+++ b/AirCasting/Dashboard/Reordering/ReorderingSessionHeader.swift
@@ -5,7 +5,6 @@ import SwiftUI
 import Resolver
 
 struct ReorderingSessionHeader: View {
-    @InjectedObject private var userSettings: UserSettings
     var session: Sessionable
     
     var body: some View {
@@ -51,11 +50,7 @@ private extension ReorderingSessionHeader {
     }
 
     func adaptTimeAndDate() -> Text {
-        var formatter: DateIntervalFormatter {
-            if userSettings.twentyFourHour { return DateFormatters.SessionCardView.utcDateIntervalFormatter }
-            return DateFormatters.SessionCardView.utcDateInterval12hFormatter
-        }
-        
+        let formatter: DateIntervalFormatter = DateFormatters.SessionCardView.shared.utcDateIntervalFormatter
         guard let start = session.startTime else { return Text("") }
         let end = session.endTime ?? DateBuilder.getFakeUTCDate()
         

--- a/AirCasting/Graph/GraphRenderers.swift
+++ b/AirCasting/Graph/GraphRenderers.swift
@@ -9,9 +9,8 @@ class TimeAxisRenderer: XAxisRenderer {
     @InjectedObject private var userSettings: UserSettings
     var rightMarginOffset: CGFloat = 50
     var dateFormatter: DateFormatter {
-        if userSettings.twentyFourHour { return DateFormatters.TimeAxisRenderer.shortUTCDateFormatter }
-        rightMarginOffset = 60
-        return DateFormatters.TimeAxisRenderer.shortUTCDate12hFormatter
+        if !userSettings.twentyFourHour { rightMarginOffset = 70 }
+        return DateFormatters.TimeAxisRenderer.shared.shortUTCDateFormatter
     }
     
     override func drawLabels(context: CGContext, pos: CGFloat, anchor: CGPoint) {

--- a/AirCasting/Graph/GraphRenderers.swift
+++ b/AirCasting/Graph/GraphRenderers.swift
@@ -3,10 +3,16 @@
 
 import SwiftUI
 import Charts
+import Resolver
 
 class TimeAxisRenderer: XAxisRenderer {
-    
-    lazy var dateFormatter = DateFormatters.TimeAxisRenderer.shortUTCDateFormatter
+    @InjectedObject private var userSettings: UserSettings
+    var rightMarginOffset: CGFloat = 50
+    var dateFormatter: DateFormatter {
+        if userSettings.twentyFourHour { return DateFormatters.TimeAxisRenderer.shortUTCDateFormatter }
+        rightMarginOffset = 60
+        return DateFormatters.TimeAxisRenderer.shortUTCDate12hFormatter
+    }
     
     override func drawLabels(context: CGContext, pos: CGFloat, anchor: CGPoint) {
         let minPxX = viewPortHandler.contentLeft
@@ -33,7 +39,7 @@ class TimeAxisRenderer: XAxisRenderer {
         
         drawLabel(context: context,
                   formattedLabel: timeRightLabel,
-                  x: maxPxX - 50,
+                  x: maxPxX - rightMarginOffset,
                   y: bottomPxY,
                   attributes: [.foregroundColor : UIColor.aircastingGray,
                                .font: Fonts.muliRegularHeadingUIFont1],

--- a/AirCasting/Graph/GraphRenderers.swift
+++ b/AirCasting/Graph/GraphRenderers.swift
@@ -6,12 +6,7 @@ import Charts
 import Resolver
 
 class TimeAxisRenderer: XAxisRenderer {
-    @InjectedObject private var userSettings: UserSettings
-    var rightMarginOffset: CGFloat = 50
-    var dateFormatter: DateFormatter {
-        if !userSettings.twentyFourHour { rightMarginOffset = 70 }
-        return DateFormatters.TimeAxisRenderer.shared.shortUTCDateFormatter
-    }
+    let dateFormatter: DateFormatter = DateFormatters.TimeAxisRenderer.shared.shortUTCDateFormatter
     
     override func drawLabels(context: CGContext, pos: CGFloat, anchor: CGPoint) {
         let minPxX = viewPortHandler.contentLeft
@@ -35,10 +30,12 @@ class TimeAxisRenderer: XAxisRenderer {
         
         let endTime = DateBuilder.getDateWithTimeIntervalSince1970(TimeInterval(maxX))
         let timeRightLabel = dateFormatter.string(from: endTime)
+        let myString = "\(timeRightLabel)"
+        let size: CGSize = myString.size(withAttributes: [.font: Fonts.muliRegularHeadingUIFont1])
         
         drawLabel(context: context,
                   formattedLabel: timeRightLabel,
-                  x: maxPxX - rightMarginOffset,
+                  x: maxPxX - size.width - 10,
                   y: bottomPxY,
                   attributes: [.foregroundColor : UIColor.aircastingGray,
                                .font: Fonts.muliRegularHeadingUIFont1],

--- a/AirCasting/SearchAndFollow/CompleteScreen/Views/CompleteScreen.swift
+++ b/AirCasting/SearchAndFollow/CompleteScreen/Views/CompleteScreen.swift
@@ -95,7 +95,7 @@ private extension CompleteScreen {
     }
 
     func formatChartTime(time: Date?) -> some View {
-        let formatter = DateFormatters.SessionCardView.pollutionChartDateFormatter
+        let formatter = DateFormatters.SessionCardView.shared.pollutionChartDateFormatter
 
         let date = time ?? DateBuilder.getFakeUTCDate()
 

--- a/AirCasting/SearchAndFollow/CompleteScreen/Views/CompleteScreen.swift
+++ b/AirCasting/SearchAndFollow/CompleteScreen/Views/CompleteScreen.swift
@@ -95,7 +95,7 @@ private extension CompleteScreen {
     }
 
     func formatChartTime(time: Date?) -> some View {
-        let formatter = DateFormatters.SessionCartView.pollutionChartDateFormatter
+        let formatter = DateFormatters.SessionCardView.pollutionChartDateFormatter
 
         let date = time ?? DateBuilder.getFakeUTCDate()
 

--- a/AirCasting/SearchAndFollow/CompleteScreen/Views/Header/StaticSessionHeader.swift
+++ b/AirCasting/SearchAndFollow/CompleteScreen/Views/Header/StaticSessionHeader.swift
@@ -2,8 +2,10 @@
 //
 
 import SwiftUI
+import Resolver
 
 struct StaticSessionHeader: View {
+    @InjectedObject private var userSettings: UserSettings
     @StateObject var viewModel: StaticSessionHeaderViewModel
     
     init(name: String, startTime: Date, endTime: Date, sensorType: String) {
@@ -53,7 +55,10 @@ private extension StaticSessionHeader {
     }
 
     func adaptTimeAndDate() -> Text {
-        let formatter = DateFormatters.SessionCartView.utcDateIntervalFormatter
+        var formatter: DateIntervalFormatter {
+            if userSettings.twentyFourHour { return DateFormatters.SessionCardView.utcDateIntervalFormatter }
+            return DateFormatters.SessionCardView.utcDateInterval12hFormatter
+        }
 
         let start = viewModel.sessionStartTime
         let end = viewModel.sessionEndTime

--- a/AirCasting/SearchAndFollow/CompleteScreen/Views/Header/StaticSessionHeader.swift
+++ b/AirCasting/SearchAndFollow/CompleteScreen/Views/Header/StaticSessionHeader.swift
@@ -5,7 +5,6 @@ import SwiftUI
 import Resolver
 
 struct StaticSessionHeader: View {
-    @InjectedObject private var userSettings: UserSettings
     @StateObject var viewModel: StaticSessionHeaderViewModel
     
     init(name: String, startTime: Date, endTime: Date, sensorType: String) {
@@ -55,11 +54,7 @@ private extension StaticSessionHeader {
     }
 
     func adaptTimeAndDate() -> Text {
-        var formatter: DateIntervalFormatter {
-            if userSettings.twentyFourHour { return DateFormatters.SessionCardView.utcDateIntervalFormatter }
-            return DateFormatters.SessionCardView.utcDateInterval12hFormatter
-        }
-
+        let formatter: DateIntervalFormatter = DateFormatters.SessionCardView.shared.utcDateIntervalFormatter
         let start = viewModel.sessionStartTime
         let end = viewModel.sessionEndTime
 

--- a/AirCasting/SearchAndFollow/SearchMap/BottomCardViewModel.swift
+++ b/AirCasting/SearchAndFollow/SearchMap/BottomCardViewModel.swift
@@ -3,8 +3,10 @@
 
 import Foundation
 import SwiftUI
+import Resolver
 
 class BottomCardViewModel: ObservableObject {
+    @InjectedObject private var userSettings: UserSettings
     @Published private var isModalScreenPresented = false
     let dataModel: BottomCardModel
     let session: PartialExternalSession
@@ -22,7 +24,10 @@ class BottomCardViewModel: ObservableObject {
     }
     
     func adaptTimeAndDate() -> String {
-        let formatter = DateFormatters.SessionCartView.utcDateIntervalFormatter
+        var formatter: DateIntervalFormatter {
+            if userSettings.twentyFourHour { return DateFormatters.SessionCardView.utcDateIntervalFormatter }
+            return DateFormatters.SessionCardView.utcDateInterval12hFormatter
+        }
         let start = dataModel.startTime
         let end = dataModel.endTime
         let string = formatter.string(from: start, to: end)

--- a/AirCasting/SearchAndFollow/SearchMap/BottomCardViewModel.swift
+++ b/AirCasting/SearchAndFollow/SearchMap/BottomCardViewModel.swift
@@ -6,7 +6,6 @@ import SwiftUI
 import Resolver
 
 class BottomCardViewModel: ObservableObject {
-    @InjectedObject private var userSettings: UserSettings
     @Published private var isModalScreenPresented = false
     let dataModel: BottomCardModel
     let session: PartialExternalSession
@@ -24,10 +23,7 @@ class BottomCardViewModel: ObservableObject {
     }
     
     func adaptTimeAndDate() -> String {
-        var formatter: DateIntervalFormatter {
-            if userSettings.twentyFourHour { return DateFormatters.SessionCardView.utcDateIntervalFormatter }
-            return DateFormatters.SessionCardView.utcDateInterval12hFormatter
-        }
+        let formatter: DateIntervalFormatter = DateFormatters.SessionCardView.shared.utcDateIntervalFormatter 
         let start = dataModel.startTime
         let end = dataModel.endTime
         let string = formatter.string(from: start, to: end)

--- a/AirCasting/SessionViews/ChartView.swift
+++ b/AirCasting/SessionViews/ChartView.swift
@@ -10,13 +10,7 @@ struct ChartView: View {
     @ObservedObject private var thresholds: ABMeasurementsViewThreshold
     @StateObject private var viewModel: ChartViewModel
     @Binding private var stream: MeasurementStreamEntity?
-    var timeFormatter: DateFormatter {
-        if userSettings.twentyFourHour {
-            return DateFormatters.SessionCardView.pollutionChartDateFormatter
-        }
-        return  DateFormatters.SessionCardView.pollutionChartDate12hFormatter
-    }
-
+    let timeFormatter: DateFormatter = DateFormatters.SessionCardView.shared.pollutionChartDateFormatter
 
     init(thresholds: ABMeasurementsViewThreshold, stream: Binding<MeasurementStreamEntity?>, session: Sessionable) {
         self.thresholds = thresholds

--- a/AirCasting/SessionViews/ChartView.swift
+++ b/AirCasting/SessionViews/ChartView.swift
@@ -5,10 +5,18 @@ import SwiftUI
 import Resolver
 
 struct ChartView: View {
+    @InjectedObject private var userSettings: UserSettings
     @Injected private var formatter: UnitFormatter
     @ObservedObject private var thresholds: ABMeasurementsViewThreshold
     @StateObject private var viewModel: ChartViewModel
     @Binding private var stream: MeasurementStreamEntity?
+    var timeFormatter: DateFormatter {
+        if userSettings.twentyFourHour {
+            return DateFormatters.SessionCardView.pollutionChartDateFormatter
+        }
+        return  DateFormatters.SessionCardView.pollutionChartDate12hFormatter
+    }
+
 
     init(thresholds: ABMeasurementsViewThreshold, stream: Binding<MeasurementStreamEntity?>, session: Sessionable) {
         self.thresholds = thresholds
@@ -34,20 +42,16 @@ struct ChartView: View {
     }
 
     var startTime: some View {
-        let formatter = DateFormatters.SessionCartView.pollutionChartDateFormatter
-
         guard let start = viewModel.chartStartTime else { return Text("") }
 
-        let string = formatter.string(from: start)
+        let string = timeFormatter.string(from: start)
         return Text(string)
     }
 
     var endTime: some View {
-        let formatter = DateFormatters.SessionCartView.pollutionChartDateFormatter
-
         let end = viewModel.chartEndTime ?? DateBuilder.getFakeUTCDate()
 
-        let string = formatter.string(from: end)
+        let string = timeFormatter.string(from: end)
         return Text(string)
     }
 

--- a/AirCasting/SessionViews/ExternalSessionsViews/ExternalSessionHeader.swift
+++ b/AirCasting/SessionViews/ExternalSessionsViews/ExternalSessionHeader.swift
@@ -5,7 +5,6 @@ import SwiftUI
 import Resolver
 
 struct ExternalSessionHeader: View {
-    @InjectedObject private var userSettings: UserSettings
     var session: Sessionable
     @ObservedObject var thresholds: ABMeasurementsViewThreshold
     @Binding var selectedStream: MeasurementStreamEntity?
@@ -74,11 +73,7 @@ private extension ExternalSessionHeader {
 
 
     func adaptTimeAndDate() -> Text {
-        var formatter: DateIntervalFormatter {
-            if userSettings.twentyFourHour { return DateFormatters.SessionCardView.utcDateIntervalFormatter }
-            return DateFormatters.SessionCardView.utcDateInterval12hFormatter
-        }
-
+        let formatter: DateIntervalFormatter = DateFormatters.SessionCardView.shared.utcDateIntervalFormatter
         let start = session.startTime ?? DateBuilder.getFakeUTCDate()
         let end = session.endTime ?? DateBuilder.getFakeUTCDate()
 

--- a/AirCasting/SessionViews/ExternalSessionsViews/ExternalSessionHeader.swift
+++ b/AirCasting/SessionViews/ExternalSessionsViews/ExternalSessionHeader.swift
@@ -2,8 +2,10 @@
 //
 
 import SwiftUI
+import Resolver
 
 struct ExternalSessionHeader: View {
+    @InjectedObject private var userSettings: UserSettings
     var session: Sessionable
     @ObservedObject var thresholds: ABMeasurementsViewThreshold
     @Binding var selectedStream: MeasurementStreamEntity?
@@ -72,7 +74,10 @@ private extension ExternalSessionHeader {
 
 
     func adaptTimeAndDate() -> Text {
-        let formatter = DateFormatters.SessionCartView.utcDateIntervalFormatter
+        var formatter: DateIntervalFormatter {
+            if userSettings.twentyFourHour { return DateFormatters.SessionCardView.utcDateIntervalFormatter }
+            return DateFormatters.SessionCardView.utcDateInterval12hFormatter
+        }
 
         let start = session.startTime ?? DateBuilder.getFakeUTCDate()
         let end = session.endTime ?? DateBuilder.getFakeUTCDate()

--- a/AirCasting/SessionViews/SessionHeaderView.swift
+++ b/AirCasting/SessionViews/SessionHeaderView.swift
@@ -21,6 +21,7 @@ struct SessionHeaderView: View {
     @State private var showingNoConnectionAlert = false
     @State private var alert: AlertInfo?
     @InjectedObject private var featureFlagsViewModel: FeatureFlagsViewModel
+    @InjectedObject private var userSettings: UserSettings
     @State var showDeleteModal = false
     @State var showAddNoteModal = false
     @State var showShareModal = false
@@ -249,7 +250,10 @@ private extension SessionHeaderView {
     }
 
     func adaptTimeAndDate() -> Text {
-        let formatter = DateFormatters.SessionCartView.utcDateIntervalFormatter
+        var formatter: DateIntervalFormatter {
+            if userSettings.twentyFourHour { return DateFormatters.SessionCardView.utcDateIntervalFormatter }
+            return DateFormatters.SessionCardView.utcDateInterval12hFormatter
+        }
         
         guard let start = session.startTime else { return Text("") }
         let end = session.endTime ?? DateBuilder.getFakeUTCDate()

--- a/AirCasting/SessionViews/SessionHeaderView.swift
+++ b/AirCasting/SessionViews/SessionHeaderView.swift
@@ -21,7 +21,6 @@ struct SessionHeaderView: View {
     @State private var showingNoConnectionAlert = false
     @State private var alert: AlertInfo?
     @InjectedObject private var featureFlagsViewModel: FeatureFlagsViewModel
-    @InjectedObject private var userSettings: UserSettings
     @State var showDeleteModal = false
     @State var showAddNoteModal = false
     @State var showShareModal = false
@@ -250,11 +249,7 @@ private extension SessionHeaderView {
     }
 
     func adaptTimeAndDate() -> Text {
-        var formatter: DateIntervalFormatter {
-            if userSettings.twentyFourHour { return DateFormatters.SessionCardView.utcDateIntervalFormatter }
-            return DateFormatters.SessionCardView.utcDateInterval12hFormatter
-        }
-        
+        let formatter: DateIntervalFormatter = DateFormatters.SessionCardView.shared.utcDateIntervalFormatter
         guard let start = session.startTime else { return Text("") }
         let end = session.endTime ?? DateBuilder.getFakeUTCDate()
         

--- a/AirCasting/Settings/SettingsView.swift
+++ b/AirCasting/Settings/SettingsView.swift
@@ -133,6 +133,7 @@ struct SettingsView: View {
             }
             keepScreenOnSwitch
             satelliteMapSwitch
+            twentyFourHourFormatSwitch
             VStack(alignment: .leading) {
                 temperatureSwitch
                 Spacer()
@@ -181,6 +182,11 @@ struct SettingsView: View {
     private var satelliteMapSwitch: some View {
         settingSwitch(toogle: $userSettings.satteliteMap,
                       label: Strings.Settings.satelliteMap)
+    }
+    
+    private var twentyFourHourFormatSwitch: some View {
+        settingSwitch(toogle: $userSettings.twentyFourHour,
+                      label: Strings.Settings.twentyFourHourFormat)
     }
 
     private var keepScreenOnSwitch: some View {

--- a/AirCasting/Utils/Constants.swift
+++ b/AirCasting/Utils/Constants.swift
@@ -40,6 +40,7 @@ struct Constants {
         static let disableMapping = "disableMapping"
         static let convertToCelsius = "convertToCelsius"
         static let satelliteMapKey = "satteliteMapKey"
+        static let twentyFourHoursFormatKey = "twentyFourHourFormatKey"
     }
     
     enum PrivacyPolicy {

--- a/AirCasting/Utils/DataFormatters.swift
+++ b/AirCasting/Utils/DataFormatters.swift
@@ -10,6 +10,8 @@ enum DateFormatters {
         @InjectedObject private var userSettings: UserSettings
         static let shared = SessionCardView()
         
+        private init() { }
+        
         var pollutionChartDateFormatter: DateFormatter {
             let df = DateFormatter()
             if userSettings.twentyFourHour { df.dateFormat = "HH:mm" } else { df.dateFormat = "h:mm a" }

--- a/AirCasting/Utils/DataFormatters.swift
+++ b/AirCasting/Utils/DataFormatters.swift
@@ -42,7 +42,7 @@ enum DateFormatters {
         }()
     }
     
-    enum SessionCartView {
+    enum SessionCardView {
         static let pollutionChartDateFormatter: DateFormatter = {
             let df = DateFormatter()
             df.dateFormat = "HH:mm"
@@ -50,9 +50,24 @@ enum DateFormatters {
             return df
         }()
         
+        static let pollutionChartDate12hFormatter: DateFormatter = {
+            let df = DateFormatter()
+            df.dateFormat = "h:mm a"
+            df.timeZone = TimeZone(abbreviation: "UTC")
+            return df
+        }()
+        
         static let utcDateIntervalFormatter: DateIntervalFormatter = {
             let df = DateIntervalFormatter()
             df.dateTemplate = "MM/dd/yy HH:mm"
+            df.timeZone = TimeZone(abbreviation: "UTC")
+            df.locale = Locale(identifier: "en_US_POSIX")
+            return df
+        }()
+        
+        static let utcDateInterval12hFormatter: DateIntervalFormatter = {
+            let df = DateIntervalFormatter()
+            df.dateTemplate = "MM/dd/yy h:mm a"
             df.timeZone = TimeZone(abbreviation: "UTC")
             df.locale = Locale(identifier: "en_US_POSIX")
             return df
@@ -82,6 +97,14 @@ enum DateFormatters {
             df.timeZone =  TimeZone.init(abbreviation: "UTC")
             df.locale = Locale(identifier: "en_US")
             df.dateFormat = "HH:mm"
+            return df
+        }()
+        
+        static let shortUTCDate12hFormatter: DateFormatter = {
+            let df = DateFormatter()
+            df.timeZone =  TimeZone.init(abbreviation: "UTC")
+            df.locale = Locale(identifier: "en_US")
+            df.dateFormat = "h:mm a"
             return df
         }()
     }

--- a/AirCasting/Utils/DataFormatters.swift
+++ b/AirCasting/Utils/DataFormatters.swift
@@ -13,23 +13,42 @@ enum DateFormatters {
         private init() { }
         
         var pollutionChartDateFormatter: DateFormatter {
-            let df = DateFormatter()
-            if userSettings.twentyFourHour { df.dateFormat = "HH:mm" } else { df.dateFormat = "h:mm a" }
-            df.timeZone = TimeZone(abbreviation: "UTC")
-            return df
+            userSettings.twentyFourHour ? Self.pollutionChartDateFormatter24 : Self.pollutionChartDateFormatter12
         }
         
         var utcDateIntervalFormatter: DateIntervalFormatter {
+            userSettings.twentyFourHour ? Self.utcDateIntervalFormatter24 : Self.utcDateIntervalFormatter12
+        }
+        
+        static let pollutionChartDateFormatter24: DateFormatter = {
+            let df = DateFormatter()
+            df.dateFormat = "HH:mm"
+            df.timeZone = TimeZone(abbreviation: "UTC")
+            return df
+        }()
+        
+        static let pollutionChartDateFormatter12: DateFormatter = {
+            let df = DateFormatter()
+            df.dateFormat = "h:mm a"
+            df.timeZone = TimeZone(abbreviation: "UTC")
+            return df
+        }()
+        
+        static let utcDateIntervalFormatter24: DateIntervalFormatter = {
             let df = DateIntervalFormatter()
-            if userSettings.twentyFourHour {
-                df.dateTemplate = "MM/dd/yy HH:mm"
-            } else {
-                df.dateTemplate = "MM/dd/yy h:mm a"
-            }
+            df.dateTemplate = "MM/dd/yy HH:mm"
             df.timeZone = TimeZone(abbreviation: "UTC")
             df.locale = Locale(identifier: "en_US_POSIX")
             return df
-        }
+        }()
+        
+        static let utcDateIntervalFormatter12: DateIntervalFormatter = {
+            let df = DateIntervalFormatter()
+            df.dateTemplate = "MM/dd/yy h:mm a"
+            df.timeZone = TimeZone(abbreviation: "UTC")
+            df.locale = Locale(identifier: "en_US_POSIX")
+            return df
+        }()
     }
     
     struct TimeAxisRenderer {

--- a/AirCasting/Utils/DataFormatters.swift
+++ b/AirCasting/Utils/DataFormatters.swift
@@ -2,8 +2,46 @@
 //
 
 import Foundation
+import Resolver
 
 enum DateFormatters {
+    
+    struct SessionCardView {
+        @InjectedObject private var userSettings: UserSettings
+        static let shared = SessionCardView()
+        
+        var pollutionChartDateFormatter: DateFormatter {
+            let df = DateFormatter()
+            if userSettings.twentyFourHour { df.dateFormat = "HH:mm" } else { df.dateFormat = "h:mm a" }
+            df.timeZone = TimeZone(abbreviation: "UTC")
+            return df
+        }
+        
+        var utcDateIntervalFormatter: DateIntervalFormatter {
+            let df = DateIntervalFormatter()
+            if userSettings.twentyFourHour {
+                df.dateTemplate = "MM/dd/yy HH:mm"
+            } else {
+                df.dateTemplate = "MM/dd/yy h:mm a"
+            }
+            df.timeZone = TimeZone(abbreviation: "UTC")
+            df.locale = Locale(identifier: "en_US_POSIX")
+            return df
+        }
+    }
+    
+    struct TimeAxisRenderer {
+        @InjectedObject private var userSettings: UserSettings
+        static let shared = TimeAxisRenderer()
+        
+        var shortUTCDateFormatter: DateFormatter {
+            let df = DateFormatter()
+            df.timeZone =  TimeZone.init(abbreviation: "UTC")
+            df.locale = Locale(identifier: "en_US")
+            if userSettings.twentyFourHour { df.dateFormat = "HH:mm" } else { df.dateFormat = "h:mm a" }
+            return df
+        }
+    }
     
     enum SessionDownloadService {
         static let decoderDateFormatter: DateFormatter = {
@@ -42,38 +80,6 @@ enum DateFormatters {
         }()
     }
     
-    enum SessionCardView {
-        static let pollutionChartDateFormatter: DateFormatter = {
-            let df = DateFormatter()
-            df.dateFormat = "HH:mm"
-            df.timeZone = TimeZone(abbreviation: "UTC")
-            return df
-        }()
-        
-        static let pollutionChartDate12hFormatter: DateFormatter = {
-            let df = DateFormatter()
-            df.dateFormat = "h:mm a"
-            df.timeZone = TimeZone(abbreviation: "UTC")
-            return df
-        }()
-        
-        static let utcDateIntervalFormatter: DateIntervalFormatter = {
-            let df = DateIntervalFormatter()
-            df.dateTemplate = "MM/dd/yy HH:mm"
-            df.timeZone = TimeZone(abbreviation: "UTC")
-            df.locale = Locale(identifier: "en_US_POSIX")
-            return df
-        }()
-        
-        static let utcDateInterval12hFormatter: DateIntervalFormatter = {
-            let df = DateIntervalFormatter()
-            df.dateTemplate = "MM/dd/yy h:mm a"
-            df.timeZone = TimeZone(abbreviation: "UTC")
-            df.locale = Locale(identifier: "en_US_POSIX")
-            return df
-        }()
-    }
-    
     enum GraphView {
         static let usLocalTimeDateFormatter: DateFormatter = {
             let df = DateFormatter()
@@ -87,24 +93,6 @@ enum DateFormatters {
             df.dateFormat = "HH:mm"
             df.locale = Locale(identifier: "en_US")
             df.timeZone = TimeZone(abbreviation: "UTC")
-            return df
-        }()
-    }
-    
-    enum TimeAxisRenderer {
-        static let shortUTCDateFormatter: DateFormatter = {
-            let df = DateFormatter()
-            df.timeZone =  TimeZone.init(abbreviation: "UTC")
-            df.locale = Locale(identifier: "en_US")
-            df.dateFormat = "HH:mm"
-            return df
-        }()
-        
-        static let shortUTCDate12hFormatter: DateFormatter = {
-            let df = DateFormatter()
-            df.timeZone =  TimeZone.init(abbreviation: "UTC")
-            df.locale = Locale(identifier: "en_US")
-            df.dateFormat = "h:mm a"
             return df
         }()
     }

--- a/AirCasting/Utils/DataFormatters.swift
+++ b/AirCasting/Utils/DataFormatters.swift
@@ -20,21 +20,21 @@ enum DateFormatters {
             userSettings.twentyFourHour ? Self.utcDateIntervalFormatter24 : Self.utcDateIntervalFormatter12
         }
         
-        static let pollutionChartDateFormatter24: DateFormatter = {
+        private static let pollutionChartDateFormatter24: DateFormatter = {
             let df = DateFormatter()
             df.dateFormat = "HH:mm"
             df.timeZone = TimeZone(abbreviation: "UTC")
             return df
         }()
         
-        static let pollutionChartDateFormatter12: DateFormatter = {
+        private static let pollutionChartDateFormatter12: DateFormatter = {
             let df = DateFormatter()
             df.dateFormat = "h:mm a"
             df.timeZone = TimeZone(abbreviation: "UTC")
             return df
         }()
         
-        static let utcDateIntervalFormatter24: DateIntervalFormatter = {
+        private static let utcDateIntervalFormatter24: DateIntervalFormatter = {
             let df = DateIntervalFormatter()
             df.dateTemplate = "MM/dd/yy HH:mm"
             df.timeZone = TimeZone(abbreviation: "UTC")
@@ -42,7 +42,7 @@ enum DateFormatters {
             return df
         }()
         
-        static let utcDateIntervalFormatter12: DateIntervalFormatter = {
+        private static let utcDateIntervalFormatter12: DateIntervalFormatter = {
             let df = DateIntervalFormatter()
             df.dateTemplate = "MM/dd/yy h:mm a"
             df.timeZone = TimeZone(abbreviation: "UTC")
@@ -61,7 +61,7 @@ enum DateFormatters {
             userSettings.twentyFourHour ? Self.shortUTCDateFormatter24 : Self.shortUTCDateFormatter12
         }
         
-        static let shortUTCDateFormatter12: DateFormatter = {
+        private static let shortUTCDateFormatter12: DateFormatter = {
             let df = DateFormatter()
             df.timeZone =  TimeZone.init(abbreviation: "UTC")
             df.locale = Locale(identifier: "en_US")
@@ -69,7 +69,7 @@ enum DateFormatters {
             return df
         }()
         
-        static let shortUTCDateFormatter24: DateFormatter = {
+        private static let shortUTCDateFormatter24: DateFormatter = {
             let df = DateFormatter()
             df.timeZone =  TimeZone.init(abbreviation: "UTC")
             df.locale = Locale(identifier: "en_US")

--- a/AirCasting/Utils/DataFormatters.swift
+++ b/AirCasting/Utils/DataFormatters.swift
@@ -36,13 +36,27 @@ enum DateFormatters {
         @InjectedObject private var userSettings: UserSettings
         static let shared = TimeAxisRenderer()
         
+        private init() { }
+        
         var shortUTCDateFormatter: DateFormatter {
+            userSettings.twentyFourHour ? Self.shortUTCDateFormatter24 : Self.shortUTCDateFormatter12
+        }
+        
+        static let shortUTCDateFormatter12: DateFormatter = {
             let df = DateFormatter()
             df.timeZone =  TimeZone.init(abbreviation: "UTC")
             df.locale = Locale(identifier: "en_US")
-            if userSettings.twentyFourHour { df.dateFormat = "HH:mm" } else { df.dateFormat = "h:mm a" }
+            df.dateFormat = "h:mm a"
             return df
-        }
+        }()
+        
+        static let shortUTCDateFormatter24: DateFormatter = {
+            let df = DateFormatter()
+            df.timeZone =  TimeZone.init(abbreviation: "UTC")
+            df.locale = Locale(identifier: "en_US")
+            df.dateFormat = "HH:mm"
+            return df
+        }()
     }
     
     enum SessionDownloadService {

--- a/AirCasting/Utils/Strings.swift
+++ b/AirCasting/Utils/Strings.swift
@@ -57,6 +57,8 @@ struct Strings {
                                                  comment: "")
         static let satelliteMap = NSLocalizedString("Satellite map",
                                                        comment: "")
+        static let twentyFourHourFormat = NSLocalizedString("Use 24-hour format",
+                                                       comment: "")
         static let crashlyticsSectionTitle = "Crashlytics integration testing:"
         
         static let appConfig = "App config"


### PR DESCRIPTION
Applied 12h format to DateFormatters which we currently use. After that conditionally decide which one is proper at the given moment. The default state for this setting ON after installation.

https://trello.com/c/PcNTJiAE/734-settings-use-24-hour-format-toggled-on-by-default