### PR TITLE
Bolder text and bolder line - GetStarted screen.

### DIFF
--- a/AirCasting/Onboarding/GetStarted.swift
+++ b/AirCasting/Onboarding/GetStarted.swift
@@ -61,14 +61,14 @@ private extension GetStarted {
     
     var getStarted: some View {
         Text(Strings.OnboardingGetStarted.getStarted)
-            .font(Fonts.moderateRegularHeading2)
+            .font(Fonts.moderateBoldHeading1)
             .frame(maxWidth: .infinity)
             .navigationBarHidden(true)
             .buttonStyle(BlueTextButtonStyle())
             .padding(12)
             .background(
                 RoundedRectangle(cornerRadius: 5)
-                    .stroke(lineWidth: 0.1)
+                    .stroke(lineWidth: 0.2)
                     .accentColor(Color.aircastingGray)
             )
             .padding()


### PR DESCRIPTION
https://trello.com/c/947D1T0q/740-intro-wizard-1st-screen-bold-button-text-reading-get-started-make-button-border-darker