### PR TITLE
Explore sessions button - fix

### DIFF
--- a/AirCasting/SearchAndFollow/SearchLocation/SearchView.swift
+++ b/AirCasting/SearchAndFollow/SearchLocation/SearchView.swift
@@ -50,10 +50,8 @@ struct SearchView: View {
             button
         }.padding()
             .onAppear(perform: {
-                viewModel.viewInitialized {
-                    presentationMode.wrappedValue.dismiss()
-                    exploreSessionsButton.exploreSessionsButtonTapped = false
-                }
+                viewModel.viewInitialized { presentationMode.wrappedValue.dismiss() }
+                exploreSessionsButton.exploreSessionsButtonTapped = false
             })
             .alert(item: $viewModel.alert, content: { $0.makeAlert() })
             .sheet(isPresented: $viewModel.isLocationPopupPresented) {


### PR DESCRIPTION
When you tap on the explore session button and then go to `create session` screen - S&F screen will always appear.

https://trello.com/c/syJ6K83c/739-navigates-to-sf