### PR TITLE
ExploreSession button bug - UITests

### DIFF
--- a/AirCasting.xcodeproj/project.pbxproj
+++ b/AirCasting.xcodeproj/project.pbxproj
@@ -471,6 +471,8 @@
 		FA4F1B732817EDDE002711B4 /* AirBeamMeasurementsDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4F1B722817EDDE002711B4 /* AirBeamMeasurementsDownloader.swift */; };
 		FA4F1B75281809B2002711B4 /* AirBeamStreamSuffixes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4F1B74281809B2002711B4 /* AirBeamStreamSuffixes.swift */; };
 		FA4F1B77281809EE002711B4 /* MeasurementsDownloaderResultModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4F1B76281809EE002711B4 /* MeasurementsDownloaderResultModel.swift */; };
+		FA5F783D289A98310016DF79 /* ExploreSessionButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5F783C289A98310016DF79 /* ExploreSessionButtonTests.swift */; };
+		FA5F783F289A98310016DF79 /* AirCastingUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5F783E289A98310016DF79 /* AirCastingUITestsLaunchTests.swift */; };
 		FAB1D4A427FAD83E004F531D /* BottomCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB1D4A327FAD83E004F531D /* BottomCardViewModel.swift */; };
 		FAB1D4A627FB28C8004F531D /* MapDownloaderSensorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB1D4A527FB28C8004F531D /* MapDownloaderSensorType.swift */; };
 		FAB34933281AB208001F6E58 /* URLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB34932281AB208001F6E58 /* URLRequest.swift */; };
@@ -483,6 +485,13 @@
 
 /* Begin PBXContainerItemProxy section */
 		4FB39E012621B53C00E5E564 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = AC7EB36A25A6FB3A00A7F2AF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = AC7EB37125A6FB3A00A7F2AF;
+			remoteInfo = AirCasting;
+		};
+		FA5F7840289A98310016DF79 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = AC7EB36A25A6FB3A00A7F2AF /* Project object */;
 			proxyType = 1;
@@ -965,6 +974,9 @@
 		FA4F1B722817EDDE002711B4 /* AirBeamMeasurementsDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirBeamMeasurementsDownloader.swift; sourceTree = "<group>"; };
 		FA4F1B74281809B2002711B4 /* AirBeamStreamSuffixes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirBeamStreamSuffixes.swift; sourceTree = "<group>"; };
 		FA4F1B76281809EE002711B4 /* MeasurementsDownloaderResultModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasurementsDownloaderResultModel.swift; sourceTree = "<group>"; };
+		FA5F783A289A98310016DF79 /* AirCastingUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AirCastingUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FA5F783C289A98310016DF79 /* ExploreSessionButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreSessionButtonTests.swift; sourceTree = "<group>"; };
+		FA5F783E289A98310016DF79 /* AirCastingUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirCastingUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		FAB1D4A327FAD83E004F531D /* BottomCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomCardViewModel.swift; sourceTree = "<group>"; };
 		FAB1D4A527FB28C8004F531D /* MapDownloaderSensorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapDownloaderSensorType.swift; sourceTree = "<group>"; };
 		FAB34932281AB208001F6E58 /* URLRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLRequest.swift; sourceTree = "<group>"; };
@@ -999,6 +1011,13 @@
 				B37DA299283189DD002A9708 /* FirebaseCrashlytics in Frameworks */,
 				3375E8D22791E7100019A5DE /* ZipArchive in Frameworks */,
 				B37DA297283189DD002A9708 /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FA5F7837289A98310016DF79 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1415,6 +1434,7 @@
 				AC787D36267B41350034B222 /* Modules */,
 				AC7EB37425A6FB3A00A7F2AF /* AirCasting */,
 				4FB39DFD2621B53C00E5E564 /* AirCastingTests */,
+				FA5F783B289A98310016DF79 /* AirCastingUITests */,
 				AC7EB37325A6FB3A00A7F2AF /* Products */,
 				A39CC233FB1B8C6B1C3FF94A /* Pods */,
 				CABAD6F2460034AEFF66A5C1 /* Frameworks */,
@@ -1427,6 +1447,7 @@
 			children = (
 				AC7EB37225A6FB3A00A7F2AF /* AirCasting.app */,
 				4FB39DFC2621B53C00E5E564 /* AirCastingTests.xctest */,
+				FA5F783A289A98310016DF79 /* AirCastingUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2472,6 +2493,15 @@
 			path = AirBeamMeasurements;
 			sourceTree = "<group>";
 		};
+		FA5F783B289A98310016DF79 /* AirCastingUITests */ = {
+			isa = PBXGroup;
+			children = (
+				FA5F783C289A98310016DF79 /* ExploreSessionButtonTests.swift */,
+				FA5F783E289A98310016DF79 /* AirCastingUITestsLaunchTests.swift */,
+			);
+			path = AirCastingUITests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -2528,13 +2558,31 @@
 			productReference = AC7EB37225A6FB3A00A7F2AF /* AirCasting.app */;
 			productType = "com.apple.product-type.application";
 		};
+		FA5F7839289A98310016DF79 /* AirCastingUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FA5F7845289A98310016DF79 /* Build configuration list for PBXNativeTarget "AirCastingUITests" */;
+			buildPhases = (
+				FA5F7836289A98310016DF79 /* Sources */,
+				FA5F7837289A98310016DF79 /* Frameworks */,
+				FA5F7838289A98310016DF79 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				FA5F7841289A98310016DF79 /* PBXTargetDependency */,
+			);
+			name = AirCastingUITests;
+			productName = AirCastingUITests;
+			productReference = FA5F783A289A98310016DF79 /* AirCastingUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		AC7EB36A25A6FB3A00A7F2AF /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1240;
+				LastSwiftUpdateCheck = 1340;
 				LastUpgradeCheck = 1320;
 				ORGANIZATIONNAME = Lunar;
 				TargetAttributes = {
@@ -2544,6 +2592,10 @@
 					};
 					AC7EB37125A6FB3A00A7F2AF = {
 						CreatedOnToolsVersion = 12.2;
+					};
+					FA5F7839289A98310016DF79 = {
+						CreatedOnToolsVersion = 13.4.1;
+						TestTargetID = AC7EB37125A6FB3A00A7F2AF;
 					};
 				};
 			};
@@ -2570,6 +2622,7 @@
 			targets = (
 				AC7EB37125A6FB3A00A7F2AF /* AirCasting */,
 				4FB39DFB2621B53C00E5E564 /* AirCastingTests */,
+				FA5F7839289A98310016DF79 /* AirCastingUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -2612,6 +2665,13 @@
 				AC7EB3B325A7152000A7F2AF /* Moderat-Trial-Black.otf in Resources */,
 				AC7EB3A525A7152000A7F2AF /* Muli-MediumItalic.ttf in Resources */,
 				AC7EB39F25A7152000A7F2AF /* Muli-ExtraLight.ttf in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FA5F7838289A98310016DF79 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3193,6 +3253,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FA5F7836289A98310016DF79 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FA5F783D289A98310016DF79 /* ExploreSessionButtonTests.swift in Sources */,
+				FA5F783F289A98310016DF79 /* AirCastingUITestsLaunchTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -3200,6 +3269,11 @@
 			isa = PBXTargetDependency;
 			target = AC7EB37125A6FB3A00A7F2AF /* AirCasting */;
 			targetProxy = 4FB39E012621B53C00E5E564 /* PBXContainerItemProxy */;
+		};
+		FA5F7841289A98310016DF79 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = AC7EB37125A6FB3A00A7F2AF /* AirCasting */;
+			targetProxy = FA5F7840289A98310016DF79 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -3533,6 +3607,63 @@
 			};
 			name = Beta;
 		};
+		FA5F7842289A98310016DF79 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = LXAGXH6CF6;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = habitatMap.AirCastingUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = AirCasting;
+			};
+			name = Debug;
+		};
+		FA5F7843289A98310016DF79 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = LXAGXH6CF6;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = habitatMap.AirCastingUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = AirCasting;
+			};
+			name = Release;
+		};
+		FA5F7844289A98310016DF79 /* Beta */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = LXAGXH6CF6;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = habitatMap.AirCastingUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = AirCasting;
+			};
+			name = Beta;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -3562,6 +3693,16 @@
 				AC7EB38225A6FB3D00A7F2AF /* Debug */,
 				AC7EB38325A6FB3D00A7F2AF /* Release */,
 				B392DC352755FA20002F0145 /* Beta */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FA5F7845289A98310016DF79 /* Build configuration list for PBXNativeTarget "AirCastingUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FA5F7842289A98310016DF79 /* Debug */,
+				FA5F7843289A98310016DF79 /* Release */,
+				FA5F7844289A98310016DF79 /* Beta */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/AirCasting.xcodeproj/xcshareddata/xcschemes/AirCasting.xcscheme
+++ b/AirCasting.xcodeproj/xcshareddata/xcschemes/AirCasting.xcscheme
@@ -38,6 +38,16 @@
                ReferencedContainer = "container:AirCasting.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FA5F7839289A98310016DF79"
+               BuildableName = "AirCastingUITests.xctest"
+               BlueprintName = "AirCastingUITests"
+               ReferencedContainer = "container:AirCasting.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/AirCastingUITests/AirCastingUITestsLaunchTests.swift
+++ b/AirCastingUITests/AirCastingUITestsLaunchTests.swift
@@ -1,0 +1,28 @@
+// Created by Lunar on 03/08/2022.
+//
+
+import XCTest
+
+class AirCastingUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/AirCastingUITests/ExploreSessionButtonTests.swift
+++ b/AirCastingUITests/ExploreSessionButtonTests.swift
@@ -1,0 +1,39 @@
+// Created by Lunar on 03/08/2022.
+//
+
+import XCTest
+
+class ExploreSessionButtonTests: XCTestCase {
+    var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        app = XCUIApplication()
+        app.launch()
+        continueAfterFailure = false
+    }
+
+    func test_tappingExpoleSessionButtonAndThenGoingToCreateSessionScreen_shouldntTriggerSFScreenAsDefault() throws {
+        let tabBar = app.tabBars["Tab Bar"]
+        
+        var searchFollowCancelButton: XCUIElement {
+            let searchFollowScreen = app.navigationBars["_TtGC7SwiftUI19UIHosting"]
+            return searchFollowScreen.buttons["Cancel"]
+        }
+        
+        var exploreSessionButton: XCUIElement {
+            let collectionViewCells = app.collectionViews/*@START_MENU_TOKEN@*/.cells/*[[".scrollViews.cells",".cells"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.scrollViews
+            return collectionViewCells.otherElements.buttons["Explore existing sessions"]
+        }
+        
+        exploreSessionButton.tap()
+        searchFollowCancelButton.tap()
+        tabBar.buttons["home"].tap()
+        tabBar.buttons["plus"].tap()
+        
+        XCTAssertFalse(app.staticTexts["Search fixed sessions"].exists)
+       
+        app.buttons["Follow session search & follow fixed sessions "].tap()
+        
+        XCTAssert(app.staticTexts["Search fixed sessions"].exists)
+    }
+}


### PR DESCRIPTION
Covered explore session button flow in which SF screen could appear always on + button click.

To check please move `exploreSessionsButton.exploreSessionsButtonTapped = false` to viewInitialized.
<img width="540" alt="Zrzut ekranu 2022-08-3 o 14 34 15" src="https://user-images.githubusercontent.com/44276070/182608834-9c70149e-e1e7-4ccd-a973-6b27eba45e8c.png">
 