### PR TITLE
Reconnect with AirBeam before clearing card during sd sync and improve alerts

### DIFF
--- a/AirCasting.xcodeproj/project.pbxproj
+++ b/AirCasting.xcodeproj/project.pbxproj
@@ -1631,14 +1631,13 @@
 		ACCEB2012763A2230040140B /* ViewsFlow */ = {
 			isa = PBXGroup;
 			children = (
+				ACCEB2082763A2230040140B /* SDSyncRootView */,
+				ACCEB2102763A2230040140B /* BackendSyncCompleted */,
+				ACCEB2162763A2230040140B /* SDSyncUnplugAB */,
+				ACCEB20D2763A2230040140B /* SDRestartAB */,
+				ACCEB2132763A2230040140B /* SDSyncingAB */,
 				ACCEB2022763A2230040140B /* SDSyncComplete */,
 				ACCEB2052763A2230040140B /* ClearingSDCard */,
-				ACCEB2082763A2230040140B /* SDSyncRootView */,
-				ACCEB20B2763A2230040140B /* SDSyncSuccess */,
-				ACCEB20D2763A2230040140B /* SDRestartAB */,
-				ACCEB2102763A2230040140B /* BackendSyncCompleted */,
-				ACCEB2132763A2230040140B /* SDSyncingAB */,
-				ACCEB2162763A2230040140B /* SDSyncUnplugAB */,
 			);
 			path = ViewsFlow;
 			sourceTree = "<group>";
@@ -1668,13 +1667,6 @@
 				ACCEB20A2763A2230040140B /* SDSyncRootView.swift */,
 			);
 			path = SDSyncRootView;
-			sourceTree = "<group>";
-		};
-		ACCEB20B2763A2230040140B /* SDSyncSuccess */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = SDSyncSuccess;
 			sourceTree = "<group>";
 		};
 		ACCEB20D2763A2230040140B /* SDRestartAB */ = {

--- a/AirCasting/ABConnector/AirBeam3Configurator.swift
+++ b/AirCasting/ABConnector/AirBeam3Configurator.swift
@@ -161,11 +161,13 @@ private extension AirBeam3Configurator {
     
     private func downloadFromSDCardModeRequest() {
         let message = hexMessageBuilder.downloadFromSDCardModeRequest
+        Log.info("Sending download from SD card mode request to peripheral")
         sendConfigMessage(data: message)
     }
     
     private func clearSDCardModeRequest() {
         let message = hexMessageBuilder.clearSDCardModeRequest
+        Log.info("Sending clear SD card mode request to peripheral")
         sendConfigMessage(data: message)
     }
     

--- a/AirCasting/ABConnector/SDCardAirBeamServices.swift
+++ b/AirCasting/ABConnector/SDCardAirBeamServices.swift
@@ -49,6 +49,8 @@ class BluetoothSDCardAirBeamServices: SDCardAirBeamServices {
         var receivedMeasurementsCount: [SDCardSessionType: Int] = [:]
         var currentSessionType: SDCardSessionType?
         
+        Log.info("## Downloading data")
+        
         configureABforSync(peripheral: peripheral)
         metadataCharacteristicObserver = bluetoothManager.subscribeToCharacteristic(DOWNLOAD_META_DATA_FROM_SD_CARD_CHARACTERISTIC_UUID) { result in
             switch result {
@@ -111,6 +113,8 @@ class BluetoothSDCardAirBeamServices: SDCardAirBeamServices {
     }
     
     func clearSDCard(of peripheral: CBPeripheral, completion: @escaping (Result<Void, Error>) -> Void) {
+        Log.info("## Sending clear config")
+        // It's possible that device has disconnected from us if there was a lot of data, so we need to connect to it again
         sendClearConfig(peripheral: peripheral)
         clearCardCharacteristicObserver = bluetoothManager.subscribeToCharacteristic(DOWNLOAD_META_DATA_FROM_SD_CARD_CHARACTERISTIC_UUID, timeout: 10) { result in
             switch result {

--- a/AirCasting/ABConnector/SDCardAirBeamServices.swift
+++ b/AirCasting/ABConnector/SDCardAirBeamServices.swift
@@ -80,7 +80,7 @@ class BluetoothSDCardAirBeamServices: SDCardAirBeamServices {
                  and in that case we want to set currentSessionTypeExpected to 0 */
                 expectedMeasurementsCount[currentSessionType!] = measurementsCount ?? 0
             case .failure(let error):
-                Log.warning("Error while receiving metadata from SD card: \(error.localizedDescription)")
+                Log.warning("[SD SYNC]  Error while receiving metadata from SD card: \(error.localizedDescription)")
                 self.finishSync { completion(.failure(error)) }
             }
         }
@@ -90,7 +90,7 @@ class BluetoothSDCardAirBeamServices: SDCardAirBeamServices {
             case .success(let data):
                 guard let data = data, let payload = String(data: data, encoding: .utf8) else { return }
                 guard let sessionType = currentSessionType else {
-                    Log.error("Received data before first metadata payload!")
+                    Log.error("[SD SYNC] Received data before first metadata payload!")
                     self.finishSync { completion(.failure(SDCardSyncError.wrongOrderOfReceivedPayload)) }
                     return
                 }
@@ -113,8 +113,7 @@ class BluetoothSDCardAirBeamServices: SDCardAirBeamServices {
     }
     
     func clearSDCard(of peripheral: CBPeripheral, completion: @escaping (Result<Void, Error>) -> Void) {
-        Log.info("## Sending clear config")
-        // It's possible that device has disconnected from us if there was a lot of data, so we need to connect to it again
+        Log.info("[SD Sync] Starting clearing SD card process")
         sendClearConfig(peripheral: peripheral)
         clearCardCharacteristicObserver = bluetoothManager.subscribeToCharacteristic(DOWNLOAD_META_DATA_FROM_SD_CARD_CHARACTERISTIC_UUID, timeout: 10) { result in
             switch result {

--- a/AirCasting/SDSync/MobileSessions/SDCardMobileSessionsSavingService.swift
+++ b/AirCasting/SDSync/MobileSessions/SDCardMobileSessionsSavingService.swift
@@ -23,14 +23,20 @@ class SDCardMobileSessionsSavingService: SDCardMobileSessionssSaver {
         // We only want to save measurements of new sessions or for sessions in standalone mode recorded with the syncing device
         var sessionsToCreate: [SessionUUID] = []
         var sessionsToIgnore: [SessionUUID] = []
+        var i = 1
         
         measurementStreamStorage.accessStorage { storage in
             do {
                 try self.fileLineReader.readLines(of: fileURL, progress: { line in
                     switch line {
                     case .line(let content):
+                        Log.info("## Saving line \(i)")
+                        i += 1
                         let measurementsRow = self.parser.parseMeasurement(lineString: content)
-                        guard let measurements = measurementsRow, !sessionsToIgnore.contains(measurements.sessionUUID) else { return }
+                        guard let measurements = measurementsRow, !sessionsToIgnore.contains(measurements.sessionUUID) else {
+                            Log.info("## ignoring line: \(content)")
+                            return
+                        }
                         
                         var session = processedSessions.first(where: { $0.uuid == measurements.sessionUUID })
                         if session == nil {
@@ -56,9 +62,11 @@ class SDCardMobileSessionsSavingService: SDCardMobileSessionssSaver {
     }
     
     private func saveData(_ streamsWithMeasurements: [SDStream: [Measurement]], to storage: HiddenCoreDataMeasurementStreamStorage, with deviceID: String, sessionsToCreate: inout [SessionUUID]) {
+        Log.info("## Saving data: \(streamsWithMeasurements.count)")
         streamsWithMeasurements.forEach { (sdStream: SDStream, measurements: [Measurement]) in
             if sessionsToCreate.contains(sdStream.sessionUUID) {
                 createSession(storage: storage, sdStream: sdStream, location: measurements.first?.location, time: measurements.first?.time, sessionsToCreate: &sessionsToCreate)
+                Log.info("## Created session")
                 saveMeasurements(measurements: measurements, storage: storage, sdStream: sdStream, deviceID: deviceID)
             } else {
                 saveMeasurements(measurements: measurements, storage: storage, sdStream: sdStream, deviceID: deviceID)
@@ -81,6 +89,7 @@ class SDCardMobileSessionsSavingService: SDCardMobileSessionssSaver {
     }
     
     private func saveMeasurements(measurements: [Measurement], storage: HiddenCoreDataMeasurementStreamStorage, sdStream: SDStream, deviceID: String) {
+        Log.info("## Saving measurements")
         do {
             var existingStreamID = try storage.existingMeasurementStream(sdStream.sessionUUID, name: sdStream.name.rawValue)
             if existingStreamID == nil {

--- a/AirCasting/SDSync/ViewsFlow/ClearingSDCard/ClearingSDCardViewModel.swift
+++ b/AirCasting/SDSync/ViewsFlow/ClearingSDCard/ClearingSDCardViewModel.swift
@@ -69,11 +69,11 @@ class ClearingSDCardViewModelDefault: ClearingSDCardViewModel, ObservableObject 
     private func getAlert() {
         switch error {
         case .undefined:
-            alert = InAppAlerts.failedSDClearingAlert { self.dismissView() }
+            alert = InAppAlerts.failedSDClearingBasicAlert { self.dismissView() }
         case .noConnection:
             alert = InAppAlerts.connectionTimeoutAlert { self.dismissView() }
         case .noClearing:
-            alert = InAppAlerts.failedSDClearingAlert { self.dismissView() }
+            alert = InAppAlerts.failedSDClearingBasicAlert { self.dismissView() }
         }
     }
     

--- a/AirCasting/SDSync/ViewsFlow/SDSyncingAB/SDSyncViewModel.swift
+++ b/AirCasting/SDSync/ViewsFlow/SDSyncingAB/SDSyncViewModel.swift
@@ -42,6 +42,7 @@ class SDSyncViewModelDefault: SDSyncViewModel, ObservableObject {
 
     func connectToAirBeamAndSync() {
         self.airBeamConnectionController.connectToAirBeam(peripheral: peripheral) { success in
+            Log.info("## Completed connecting to AB")
             guard success else {
                 DispatchQueue.main.async {
                     self.presentNextScreen = success
@@ -63,6 +64,7 @@ class SDSyncViewModelDefault: SDSyncViewModel, ObservableObject {
                     }
                 }
             }, completion: { [weak self] result in
+                Log.info("## Completed syncing with result: \(result)")
                 guard let self = self else { return }
                 if result {
                     self.clearSDCard()

--- a/AirCasting/SDSync/ViewsFlow/SDSyncingAB/SyncingABView.swift
+++ b/AirCasting/SDSync/ViewsFlow/SDSyncingAB/SyncingABView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct SyncingABView<VM: SDSyncViewModel>: View {
-    @Environment(\.presentationMode) var presentationMode
     @StateObject var viewModel: VM
     @State var progressTitle: String?
     @State var progressCount: String?
@@ -31,6 +30,8 @@ struct SyncingABView<VM: SDSyncViewModel>: View {
             }
             Spacer()
         }
+        .alert(item: $viewModel.alert, content: { $0.makeAlert() })
+        .onChange(of: viewModel.shouldDismiss, perform: { $0 ? creatingSessionFlowContinues = false : nil })
         .padding()
         .background(navigationLink)
         .onReceive(viewModel.progress, perform: { newProgress in
@@ -39,7 +40,6 @@ struct SyncingABView<VM: SDSyncViewModel>: View {
                 self.progressCount = "\(progress.current)/\(progress.total)"
             }
         })
-        .alert(isPresented: $viewModel.presentFailedSyncAlert, content: { connectionTimeOutAlert })
         .onAppear(perform: {
             /* App is pushing the next view before this view is fully loaded.
              It resulted with showing next view and going back to this one.
@@ -86,14 +86,6 @@ extension SyncingABView {
                 .progressViewStyle(CircularProgressViewStyle(tint: Color.white))
                 .scaleEffect(2)
         }
-    }
-
-    var connectionTimeOutAlert: Alert {
-        Alert(title: Text(Strings.SyncingABView.alertTitle),
-              message: Text(Strings.SyncingABView.alertMessage),
-              dismissButton: .default(Text(Strings.Commons.gotIt), action: {
-            presentationMode.wrappedValue.dismiss()
-        }))
     }
 
     var navigationLink: some View {

--- a/AirCasting/Utils/InAppAlerts.swift
+++ b/AirCasting/Utils/InAppAlerts.swift
@@ -82,14 +82,6 @@ struct InAppAlerts {
                                       action: dismiss) ])
     }
     
-    static func failedSDClearingAlert(dismiss: (@escaping () -> Void)) -> AlertInfo {
-        AlertInfo(title: Strings.ClearingSDCardView.failedClearingAlertTitle,
-                  message: Strings.ClearingSDCardView.failedClearingAlertMessage,
-                  buttons: [
-                    .default(title: Strings.Commons.gotIt,
-                             action: dismiss) ])
-    }
-    
     static func microphonePermissionAlert() -> AlertInfo {
         AlertInfo(title: Strings.MicrophoneAlert.title,
                   message: Strings.MicrophoneAlert.message,
@@ -244,6 +236,62 @@ struct InAppAlerts {
             buttons: [
                 .default(title: Strings.Commons.ok, action: nil)
             ])
+    }
+    
+    // MARK: - SD Sync
+    static func failedSDClearingBasicAlert(dismiss: (@escaping () -> Void)) -> AlertInfo {
+        AlertInfo(title: Strings.ClearingSDCardView.failedClearingAlertTitle,
+                  message: Strings.ClearingSDCardView.failedClearingAlertMessage,
+                  buttons: [
+                    .default(title: Strings.Commons.gotIt,
+                             action: dismiss) ])
+    }
+    
+    static func failedSDClearingAlert(dismiss: (@escaping () -> Void)) -> AlertInfo {
+        AlertInfo(title: Strings.SDSyncAlerts.clearFailTitle,
+                  message: Strings.SDSyncAlerts.clearFailMessage,
+                  buttons: [
+                    .default(title: Strings.Commons.gotIt,
+                             action: dismiss) ])
+    }
+    
+    static func sdSyncUnidentifiableDeviceAlert(dismiss: (@escaping () -> Void)) -> AlertInfo {
+        AlertInfo(title: Strings.SDSyncAlerts.genericFailTitle,
+                  message: Strings.SDSyncAlerts.unidetifiableDeviceMessage,
+                  buttons: [
+                    .default(title: Strings.Commons.gotIt,
+                             action: dismiss) ])
+    }
+    
+    static func sdSyncFilesCorruptedAlert(dismiss: (@escaping () -> Void)) -> AlertInfo {
+        AlertInfo(title: Strings.SDSyncAlerts.genericFailTitle,
+                  message: Strings.SDSyncAlerts.readingFilesFailMessage,
+                  buttons: [
+                    .default(title: Strings.Commons.gotIt,
+                             action: dismiss) ])
+    }
+    
+    static func sdSyncReadingDataAlert(dismiss: (@escaping () -> Void)) -> AlertInfo {
+        AlertInfo(title: Strings.SDSyncAlerts.genericFailTitle,
+                  message: Strings.SDSyncAlerts.readingDataFailMessage,
+                  buttons: [
+                    .default(title: Strings.Commons.gotIt,
+                             action: dismiss) ])
+    }
+    
+    static func sdSyncFixedFailAlert(dismiss: (@escaping () -> Void)) -> AlertInfo {
+        AlertInfo(title: Strings.SDSyncAlerts.genericFailTitle,
+                  message: Strings.SDSyncAlerts.processingFixedFailMessage,
+                  buttons: [
+                    .default(title: Strings.Commons.gotIt,
+                             action: dismiss) ])
+    }
+    static func sdSyncMobileFailAlert(dismiss: (@escaping () -> Void)) -> AlertInfo {
+        AlertInfo(title: Strings.SDSyncAlerts.genericFailTitle,
+                  message: Strings.SDSyncAlerts.processingMobileFailMessage,
+                  buttons: [
+                    .default(title: Strings.Commons.gotIt,
+                             action: dismiss) ])
     }
 }
 

--- a/AirCasting/Utils/Strings.swift
+++ b/AirCasting/Utils/Strings.swift
@@ -816,13 +816,25 @@ struct Strings {
     enum SyncingABView {
         static let message: String = NSLocalizedString("Keep your AirBeam unplugged and close to your iPhone",
                                                        comment: "")
-        static let alertTitle: String = NSLocalizedString("SD card sync failed",
-                                                          comment: "")
-        static let alertMessage: String = NSLocalizedString("We're sorry, something unexpected caused the SD card sync to fail. Please try again", comment: "")
         static let startingSyncTitle: String = NSLocalizedString("Syncing...",
                                                                  comment: "")
         static let finishingSyncTitle: String = NSLocalizedString("Finalizing...",
                                                                   comment: "")
+    }
+    
+    enum SDSyncAlerts {
+        static let clearFailTitle: String = NSLocalizedString("Clearing SD card failed",
+                                                          comment: "")
+        static let clearFailMessage: String = NSLocalizedString("We're sorry, something unexpected caused clearing SD card to fail. You can try to clear the card again from settings view.", comment: "")
+        static let genericFailTitle: String = NSLocalizedString("SD card sync failed",
+                                                          comment: "")
+        static let genericFailMessage: String = NSLocalizedString("We're sorry, something unexpected caused the SD card sync to fail. Please try again", comment: "")
+        static let unidetifiableDeviceMessage: String = NSLocalizedString("Unable to identify the device", comment: "")
+        static let readingFilesFailMessage: String = NSLocalizedString("Data on SD card seems to be corrupted.", comment: "")
+        static let readingDataFailMessage: String = NSLocalizedString("Something interrupted connection with the AirBeam. Please try again.", comment: "")
+        static let processingFixedFailMessage: String = NSLocalizedString("Something went wrong when sending fixed sessions data to the server. Please try again later.", comment: "")
+        static let processingMobileFailMessage: String = NSLocalizedString("Something went wrong when saving mobile sessions data to the database. Please try again.", comment: "")
+        
     }
     
     enum SDSyncCompleteView {


### PR DESCRIPTION
* Check if AB is connected before attempting to clear SD card and try to reconnect if it disconnected
* Add different alerts for different failures in SD Sync process