### PR TITLE
Allow for editing not synced sessions

### DIFF
--- a/AirCasting/SessionViews/SessionHeaderView.swift
+++ b/AirCasting/SessionViews/SessionHeaderView.swift
@@ -104,7 +104,7 @@ struct SessionHeaderView: View {
             let vm = EditLocationlessSessionViewModel(sessionUUID: session.uuid, sessionName: session.name ?? "", sessionTags: session.tags ?? "")
             EditView(viewModel: vm)
         } else {
-            let vm = EditSessionViewModel(sessionUUID: session.uuid)
+            let vm = EditSessionViewModel(sessionUUID: session.uuid, sessionName: session.name ?? "", sessionTags: session.tags ?? "", sessionSynced: session.urlLocation != nil)
             EditView(viewModel: vm)
         }
     }


### PR DESCRIPTION
Before, user couldn't edit a session if it wasn't previously sent to backend. It was happening because when entering session editing view we were attempting to get its most recent data from backend and it was failing because session wasn't there. Now, we will allow users to edit sessions that weren't sent to backend (because eg. user has "sync only through wifi" turned on).