### PR TITLE
Check for internet connection and show the right alert in edit view

### DIFF
--- a/AirCasting/Utils/InAppAlerts.swift
+++ b/AirCasting/Utils/InAppAlerts.swift
@@ -39,6 +39,15 @@ struct InAppAlerts {
                   ])
     }
     
+    static func noNetworkEditAlert(dismiss: (() -> Void)? = nil) -> AlertInfo {
+        AlertInfo(title: Strings.InAppAlerts.noInternetConnectionTitle,
+                  message: Strings.InAppAlerts.noInternetConnectionEditMessage,
+                  buttons: [
+                    .default(title: Strings.Commons.gotIt,
+                             action: dismiss)
+                  ])
+    }
+    
     static func noWifiNetworkSyncAlert(dismiss: (() -> Void)? = nil) -> AlertInfo {
         AlertInfo(title: Strings.InAppAlerts.noWifiConnectionTitle,
                   message: Strings.InAppAlerts.noWifiConnectionSyncMessage,

--- a/AirCasting/Utils/Strings.swift
+++ b/AirCasting/Utils/Strings.swift
@@ -925,6 +925,8 @@ struct Strings {
                                                                      comment: "")
         static let noInternetConnectionSyncMessage: String = NSLocalizedString("Connect device to the Internet to sync sessions.",
                                                                      comment: "")
+        static let noInternetConnectionEditMessage: String = NSLocalizedString("Connect device to the Internet to edit sessions.",
+                                                                     comment: "")
         static let noWifiConnectionSyncMessage: String = NSLocalizedString("Connect device to Wi-Fi network to sync sessions or turn off \"sync only through Wi-Fi\" setting.",
                                                                    comment: "")
         static let noInternetConnectionButton: String = NSLocalizedString("Got it!",


### PR DESCRIPTION
# What was done?

This PR adds a network check to the edit view and show the right alert when a user tries to edit a session but they don't have an internet connection.