### PR TITLE
Expand card when doing a mobile session.

### DIFF
--- a/AirCasting/CoreData/Storages/MeasurementStreamStorage.swift
+++ b/AirCasting/CoreData/Storages/MeasurementStreamStorage.swift
@@ -17,7 +17,7 @@ protocol MeasurementStreamStorageContextUpdate {
     func saveThresholdFor(sensorName: String, thresholdVeryHigh: Int32, thresholdHigh: Int32, thresholdMedium: Int32, thresholdLow: Int32, thresholdVeryLow: Int32) throws
     func saveMeasurementStream(_ stream: MeasurementStream, for sessionUUID: SessionUUID) throws -> MeasurementStreamLocalID
     @discardableResult func createSession(_ session: Session) throws -> SessionEntity
-    func createSessionAndMeasurementStream(_ session: Session, _ stream: MeasurementStream) throws -> MeasurementStreamLocalID
+    func createSessionAndMeasurementStream(_ session: Session, _ stream: MeasurementStream) throws 
     func updateSessionStatus(_ sessionStatus: SessionStatus, for sessionUUID: SessionUUID) throws
     func updateSessionEndtime(_ endTime: Date, for sessionUUID: SessionUUID) throws
     func updateSessionNameAndTags(name: String, tags: String, for sessionUUID: SessionUUID) throws
@@ -178,10 +178,10 @@ final class HiddenCoreDataMeasurementStreamStorage: MeasurementStreamStorageCont
         return try saveMeasurementStream(for: sessionEntity, context: context, stream)
     }
 
-    func createSessionAndMeasurementStream(_ session: Session, _ stream: MeasurementStream) throws -> MeasurementStreamLocalID {
+    func createSessionAndMeasurementStream(_ session: Session, _ stream: MeasurementStream) throws {
         let sessionEntity = newSessionEntity()
         updateSessionParamsService.updateSessionsParams(sessionEntity, session: session)
-        return try saveMeasurementStream(for: sessionEntity, context: context, stream)
+        _ = try saveMeasurementStream(for: sessionEntity, context: context, stream)
     }
 
     func existingMeasurementStream(_ sessionUUID: SessionUUID, name: String) throws -> MeasurementStreamLocalID? {

--- a/AirCasting/CoreData/Storages/UIStorage.swift
+++ b/AirCasting/CoreData/Storages/UIStorage.swift
@@ -11,6 +11,7 @@ protocol UIStorage {
 protocol UIStorageContextUpdate {
     func cardStateToggle(for sessionUUID: SessionUUID) throws
     func changeStream(for sessionUUID: SessionUUID, stream: String) throws
+    func switchCardExpanded(to newValue: Bool, sessionUUID: SessionUUID) throws 
     func save() throws
 }
 
@@ -52,6 +53,17 @@ final class HiddenCoreDataUIStorage: UIStorageContextUpdate {
         let sessionEntity = try context.existingSession(uuid: sessionUUID)
         createUIStateIfNeeded(entity: sessionEntity)
         sessionEntity.userInterface?.expandedCard.toggle()
+    }
+    
+    func switchCardExpanded(to newValue: Bool, sessionUUID: SessionUUID) throws {
+        if let sessionEntity = try? context.existingExternalSession(uuid: sessionUUID) {
+            createUIStateIfNeededForExternalSession(entity: sessionEntity)
+            sessionEntity.userInterface?.expandedCard = newValue
+            return
+        }
+        let sessionEntity = try context.existingSession(uuid: sessionUUID)
+        createUIStateIfNeeded(entity: sessionEntity)
+        sessionEntity.userInterface?.expandedCard = newValue
     }
     
     func changeStream(for sessionUUID: SessionUUID, stream: String) throws {

--- a/AirCasting/MicrophoneSession/LevelMeasurementController/DecibelMeasurementSaveable.swift
+++ b/AirCasting/MicrophoneSession/LevelMeasurementController/DecibelMeasurementSaveable.swift
@@ -8,6 +8,7 @@ final class DecibelMeasurementSaveable: MeasurementSaveable {
     private let session: Session
     private var databasePrepared: Bool = false
     @Injected private var persistence: MeasurementStreamStorage
+    @Injected private var uiStorage: UIStorage
     @Injected private var locationService: LocationService
     
     enum DecibelMeasurementSaveableError: Error {
@@ -73,7 +74,14 @@ final class DecibelMeasurementSaveable: MeasurementSaveable {
         persistence.accessStorage { [weak self] storage in
             do {
                 guard let self = self else { return }
-                _ = try storage.createSessionAndMeasurementStream(self.session, stream)
+                try storage.createSessionAndMeasurementStream(self.session, stream)
+                self.uiStorage.accessStorage { storage in
+                    do {
+                        try storage.switchCardExpanded(to: true, sessionUUID: self.session.uuid)
+                    } catch {
+                        completion(.failure(error))
+                    }
+                }
                 completion(.success(()))
             } catch {
                 completion(.failure(error))

--- a/AirCasting/MobilePeripheralSessionManager.swift
+++ b/AirCasting/MobilePeripheralSessionManager.swift
@@ -11,6 +11,7 @@ class MobilePeripheralSessionManager {
 
     private let measurementStreamStorage: MeasurementStreamStorage
     @Injected private var locationTracker: LocationTracker
+    @Injected private var uiStorage: UIStorage
 
     private var activeMobileSession: MobileSession?
 
@@ -27,11 +28,19 @@ class MobilePeripheralSessionManager {
                 let entity = BluetoothConnectionEntity(context: sessionReturned.managedObjectContext!)
                 entity.peripheralUUID = peripheral.identifier.description
                 entity.session = sessionReturned
+                guard let self = self else { return }
+                self.uiStorage.accessStorage { storage in
+                    do {
+                        try storage.switchCardExpanded(to: true, sessionUUID: session.uuid)
+                    } catch {
+                        Log.error("\(error)")
+                    }
+                }
                 DispatchQueue.main.async {
                     if !session.locationless {
-                        self?.locationTracker.start()
+                        self.locationTracker.start()
                     }
-                    self?.activeMobileSession = MobileSession(peripheral: peripheral, session: session)
+                    self.activeMobileSession = MobileSession(peripheral: peripheral, session: session)
                 }
             } catch {
                 Log.info("\(error)")


### PR DESCRIPTION
**What was done:**
The initial state of the card should be set to _expanded_ when doing a mobile session (BT or MIC)

https://trello.com/c/4zpZcHT1/784-mobile-active-make-expanded-card-the-default-state