### PR TITLE
Assign the same timestamp to given measurements chunk.

### DIFF
--- a/AirCasting/ABConnector/BluetoothManager.swift
+++ b/AirCasting/ABConnector/BluetoothManager.swift
@@ -34,18 +34,6 @@ extension BluetoothCommunicator {
 
 class BluetoothManager: NSObject, BluetoothCommunicator, ObservableObject {
     
-    class PeripheralMeasurementTimeManager {
-        private(set) var collectedValuesCount: Int = 5
-        private(set) var currentTime: Date = DateBuilder.getRawDate().currentUTCTimeZoneDate
-        
-        func startNewValuesRound() {
-            currentTime = DateBuilder.getRawDate().currentUTCTimeZoneDate
-            collectedValuesCount = 0
-        }
-        
-        func incrementCounter() { collectedValuesCount += 1 }
-    }
-
     lazy var centralManager: CBCentralManager = {
         let centralManager = CBCentralManager()
         centralManager.delegate = self
@@ -61,7 +49,6 @@ class BluetoothManager: NSObject, BluetoothCommunicator, ObservableObject {
     @Published var centralManagerState: CBManagerState = .unknown
     @Published var mobileSessionReconnected = false
     var observed: NSKeyValueObservation?
-    var peripheralMeasurementManager = PeripheralMeasurementTimeManager()
 
     let mobilePeripheralSessionManager: MobilePeripheralSessionManager
     @Injected private var featureFlagProvider: FeatureFlagProvider
@@ -293,9 +280,7 @@ extension BluetoothManager: CBPeripheralDelegate {
         }
 
         if let parsedMeasurement = parseData(data: value) {
-            if peripheralMeasurementManager.collectedValuesCount == 5 { peripheralMeasurementManager.startNewValuesRound() }
-            mobilePeripheralSessionManager.handlePeripheralMeasurement(PeripheralMeasurement(peripheral: peripheral, measurementStream: parsedMeasurement), time: peripheralMeasurementManager.currentTime)
-            peripheralMeasurementManager.incrementCounter()
+            mobilePeripheralSessionManager.handlePeripheralMeasurement(PeripheralMeasurement(peripheral: peripheral, measurementStream: parsedMeasurement))
         }
     }
 


### PR DESCRIPTION
We were having different timestamps assigned to one chunk (5 of them: F, PM1..) of measurements. The reason is that: we were saving each one of them separately which sometimes resulted in a slight delay.

It should be tested for +2 h and +9 hours sessions, but I think Michael and Grzester can do it later, as for now, those early tests done by me were successful.

https://trello.com/c/Y4OVpvQH/347-improve-2hr-9hr-averaging-function-so-all-the-averages-are-precisely-5-sec-1-min