### PR TITLE
Change share sheet viewModel to StateObject

### DIFF
--- a/AirCasting/SessionViews/ShareSession/ShareSessionView.swift
+++ b/AirCasting/SessionViews/ShareSession/ShareSessionView.swift
@@ -7,7 +7,7 @@ import SwiftUI
 
 
 struct ShareSessionView<VM: ShareSessionViewModel>: View {
-    @ObservedObject var viewModel: VM
+    @StateObject var viewModel: VM
     
     var body: some View {
         ZStack {


### PR DESCRIPTION
This PR fixes a bug that was causing the share sheet to refresh every time a new measurement was downloaded. Because of that, the input of the user was cleared and that could have been an annoying experience.