### PR TITLE
Add validation for note text

### DIFF
--- a/AirCasting/Notes/AddNote/AddNoteView.swift
+++ b/AirCasting/Notes/AddNote/AddNoteView.swift
@@ -17,6 +17,9 @@ struct AddNoteView<VM: AddNoteViewModel>: View {
                     description
                     addPhotoButton
                     noteField
+                    if viewModel.shouldShowError {
+                        errorMessage(text: Strings.AddNoteView.error)
+                    }
                     photo
                     continueButton
                     cancelButton

--- a/AirCasting/Notes/AddNote/AddNoteViewModel.swift
+++ b/AirCasting/Notes/AddNote/AddNoteViewModel.swift
@@ -5,6 +5,7 @@ import Resolver
 
 class AddNoteViewModel: ObservableObject {
     @Published var noteText = ""
+    @Published var shouldShowError = false
     
     private let notesHandler: NotesHandler
     private let exitRoute: () -> Void
@@ -17,6 +18,10 @@ class AddNoteViewModel: ObservableObject {
     }
     
     func continueTapped(selectedPictureURL: URL?) {
+        guard !noteText.isEmpty else {
+            shouldShowError = true
+            return
+        }
         notesHandler.addNote(noteText: noteText, photo: selectedPictureURL, withLocation: trackLocation)
         exitRoute()
     }

--- a/AirCasting/Notes/EditNote/EditNoteView.swift
+++ b/AirCasting/Notes/EditNote/EditNoteView.swift
@@ -14,6 +14,9 @@ struct EditNoteView<VM: EditNoteViewModel>: View {
                     title
                     description
                     noteField
+                    if viewModel.shouldShowError {
+                        errorMessage(text: Strings.AddNoteView.error)
+                    }
                     photo
                     continueButton
                     deleteButton

--- a/AirCasting/Notes/EditNote/EditNoteViewModel.swift
+++ b/AirCasting/Notes/EditNote/EditNoteViewModel.swift
@@ -6,6 +6,7 @@ import Resolver
 protocol EditNoteViewModel: ObservableObject {
     var noteText: String { get set }
     var notePhoto: URL? { get set }
+    var shouldShowError: Bool { get set }
     func saveTapped()
     func deleteTapped()
     func cancelTapped()
@@ -14,6 +15,7 @@ protocol EditNoteViewModel: ObservableObject {
 class EditNoteViewModelDefault: EditNoteViewModel, ObservableObject {
     @Published var noteText = ""
     @Published var notePhoto: URL? = nil
+    @Published var shouldShowError = false
     private var note: Note!
     private let notesHandler: NotesHandler
     private let exitRoute: () -> Void
@@ -33,6 +35,10 @@ class EditNoteViewModelDefault: EditNoteViewModel, ObservableObject {
     }
     
     func saveTapped() {
+        guard !noteText.isEmpty else {
+            shouldShowError = true
+            return
+        }
         notesHandler.updateNote(note: note, newText: noteText, completion: {
             self.exitRoute()
         })

--- a/AirCasting/Utils/Strings.swift
+++ b/AirCasting/Utils/Strings.swift
@@ -1006,6 +1006,8 @@ struct Strings {
                                                      comment: "")
         static let description: String = NSLocalizedString("Your note will be timestamped and displayed on the AirCasting map",
                                                            comment: "")
+        static let error: String = NSLocalizedString("Text can't be blank",
+                                                     comment: "")
         static let photoButton = NSLocalizedString("Tap to add picture", comment: "")
         static let retakePhotoButton = NSLocalizedString("Retake a picture", comment: "")
         static let placeholder: String = NSLocalizedString("Note",


### PR DESCRIPTION
# Why was it done?
When we are sending a note without a text backend sends 400 response and session can't be synced.

https://trello.com/c/rGlWKHMU