### PR TITLE
Save photo url after downloading session from backed

### DIFF
--- a/AirCasting/CoreData/PersistenceController+Database.swift
+++ b/AirCasting/CoreData/PersistenceController+Database.swift
@@ -58,6 +58,7 @@ extension PersistenceController: SessionInsertable {
                         noteEntity.lat = $0.latitude
                         noteEntity.long = $0.longitude
                         noteEntity.number = Int64($0.number)
+                        noteEntity.photoLocation = $0.photoLocation
                         noteEntity.session = sessionEntity
                     }
                     $0.measurementStreams?.forEach {

--- a/AirCasting/SessionsSynchronization/Adapters/DataStore/SessionSynchronizationDatabase.swift
+++ b/AirCasting/SessionsSynchronization/Adapters/DataStore/SessionSynchronizationDatabase.swift
@@ -64,7 +64,8 @@ final class SessionSynchronizationDatabase: SessionSynchronizationStore {
                                       text: $0.text,
                                       latitude: $0.latitude,
                                       longitude: $0.longitude,
-                                      number: $0.number)
+                                      number: $0.number,
+                                      photoLocation: $0.photoLocation)
                     }
                     let location: CLLocationCoordinate2D? = {
                         guard let latitude = sessionData.latitude,

--- a/AirCasting/SessionsSynchronization/Adapters/Services/SessionDownloadService.swift
+++ b/AirCasting/SessionsSynchronization/Adapters/Services/SessionDownloadService.swift
@@ -63,6 +63,7 @@ final class SessionDownloadService: SessionDownstream, MeasurementsDownloadable 
                     let sessionData = try decoder.decode(SessionsSynchronization.SessionDownstreamData.self, from: response.data)
                     completion(.success(sessionData))
                 } catch {
+                    Log.error("Failed to download session with uuid \(session): \(error)")
                     completion(.failure(error))
                 }
             case .failure(let error):

--- a/AirCasting/SessionsSynchronization/Controller/Interfaces/SessionDownstream.swift
+++ b/AirCasting/SessionsSynchronization/Controller/Interfaces/SessionDownstream.swift
@@ -69,5 +69,6 @@ extension SessionsSynchronization {
         let latitude: Double
         let longitude: Double
         let number: Int
+        let photoLocation: String?
     }
 }

--- a/AirCasting/SessionsSynchronization/Controller/Interfaces/SessionSynchronizationStore.swift
+++ b/AirCasting/SessionsSynchronization/Controller/Interfaces/SessionSynchronizationStore.swift
@@ -90,6 +90,7 @@ extension SessionsSynchronization {
         let latitude: Double
         let longitude: Double
         let number: Int
+        let photoLocation: URL?
     }
     
     struct NotesResultData {

--- a/AirCasting/SessionsSynchronization/Controller/Utils/SessionsSynchronizationStoreDataConverter.swift
+++ b/AirCasting/SessionsSynchronization/Controller/Utils/SessionsSynchronizationStoreDataConverter.swift
@@ -31,7 +31,8 @@ struct SynchronizationDataConverter {
                 text: note.text,
                 latitude: note.latitude,
                 longitude: note.longitude,
-                number: note.number)
+                number: note.number,
+                photoLocation: note.photoLocation != nil ? URL(string: note.photoLocation!) : nil)
         }
         return .init(uuid: download.uuid,
                      contribute: download.contribute,
@@ -142,7 +143,8 @@ struct SynchronizationDataConverter {
                          text: note.text,
                          latitude: note.latitude,
                          longitude: note.longitude,
-                         number: note.number)
+                         number: note.number,
+                         photoLocation: note.photoLocation)
         }
         
         return SessionsSynchronization.SessionStoreSessionData(uuid: entity.uuid,


### PR DESCRIPTION
# What was done?

This PR adds a part of adding photos to notes that was missing, which is saving photo url after we receive session data when downloading it during sync with backed.

# Why was it done?
Before, when user signed out and signed backed in to the app, notes photos were not appearing. Now they are.

https://trello.com/c/hYCtbmeL