### PR TITLE
Proper size of + screen buttons.

### DIFF
--- a/AirCasting/CreateSessionViews/ChooseSessionType/ChooseSessionTypeView.swift
+++ b/AirCasting/CreateSessionViews/ChooseSessionType/ChooseSessionTypeView.swift
@@ -18,6 +18,14 @@ struct ChooseSessionTypeView: View {
     @State private var buttonHeight = CGFloat.zero
     @InjectedObject private var featureFlagsViewModel: FeatureFlagsViewModel
     
+    var shouldShowSDSyncButton: Bool {
+        featureFlagsViewModel.enabledFeatures.contains(.sdCardSync)
+    }
+    
+    var shouldShowFollowSessionButton: Bool {
+        featureFlagsViewModel.enabledFeatures.contains(.searchAndFollow)
+    }
+    
     var shouldGoToChooseSessionScreen: Bool {
         (tabSelection.selection == .createSession && emptyDashboardButtonTapped.mobileWasTapped) ? true : false
     }
@@ -239,7 +247,7 @@ struct ChooseSessionTypeView: View {
                 .padding(.horizontal)
                 Spacer().frame(height: spacerHeight)
                 VStack(alignment: .leading, spacing: 15) {
-                    let horizontalSpacerRatio = 10.5
+                    let horizontalSpacerRatio = 17.0
                     HStack {
                         recordNewLabel
                         Spacer()
@@ -257,12 +265,15 @@ struct ChooseSessionTypeView: View {
                         orLabel
                     }
                     HStack {
-                        if featureFlagsViewModel.enabledFeatures.contains(.sdCardSync) {
-                            sdSyncButton
-                        }
-                        Spacer(minLength: geometry.size.width / horizontalSpacerRatio)
-                        if featureFlagsViewModel.enabledFeatures.contains(.searchAndFollow) {
-                            followSessionButton
+                        switch (shouldShowSDSyncButton, shouldShowFollowSessionButton) {
+                        case (false, true):
+                            shouldShowFollowSessionButton ? AnyView(followSessionButton) : AnyView(Color.clear)
+                            Spacer(minLength: geometry.size.width / horizontalSpacerRatio)
+                            shouldShowSDSyncButton ? AnyView(sdSyncButton) : AnyView(Color.clear)
+                        default:
+                            shouldShowSDSyncButton ? AnyView(sdSyncButton) : AnyView(Color.clear)
+                            Spacer(minLength: geometry.size.width / horizontalSpacerRatio)
+                            shouldShowFollowSessionButton ? AnyView(followSessionButton) : AnyView(Color.clear)
                         }
                     }
                     Spacer().frame(height: innerSpacerHeight)

--- a/AirCasting/CreateSessionViews/ChooseSessionType/ChooseSessionTypeView.swift
+++ b/AirCasting/CreateSessionViews/ChooseSessionType/ChooseSessionTypeView.swift
@@ -267,9 +267,9 @@ struct ChooseSessionTypeView: View {
                     HStack {
                         switch (shouldShowSDSyncButton, shouldShowFollowSessionButton) {
                         case (false, true):
-                            shouldShowFollowSessionButton ? AnyView(followSessionButton) : AnyView(Color.clear)
+                            followSessionButton
                             Spacer(minLength: geometry.size.width / horizontalSpacerRatio)
-                            shouldShowSDSyncButton ? AnyView(sdSyncButton) : AnyView(Color.clear)
+                            Color.clear
                         default:
                             shouldShowSDSyncButton ? AnyView(sdSyncButton) : AnyView(Color.clear)
                             Spacer(minLength: geometry.size.width / horizontalSpacerRatio)


### PR DESCRIPTION
**Goal:**
- make smaller spaces between buttons to fit `mobile sessions` in one line and `Sync data from AB3` in two lines
- improve the design so that, when one icon will be missing - it will still look good (iPhone SE case)
- when only one icon appear on the bottom, move it to the left side

