### PR TITLE
Overfiring timer for statistics container fixed

### DIFF
--- a/AirCasting/Graph/AirCastingGraph.swift
+++ b/AirCasting/Graph/AirCastingGraph.swift
@@ -115,7 +115,6 @@ class AirCastingGraph: UIView {
             zoomoutToThirtyMinutes(dataSet: dataSet)
         }
         layoutNotes()
-        callDateRangeChangeObserver()
     }
     
     private func callDateRangeChangeObserver() {

--- a/AirCasting/Graph/External/ExternalGraphView.swift
+++ b/AirCasting/Graph/External/ExternalGraphView.swift
@@ -4,9 +4,9 @@ import Resolver
 struct ExternalGraphView<StatsViewModelType>: View where StatsViewModelType: StatisticsContainerViewModelable {
     let session: ExternalSessionEntity
     let thresholds: ABMeasurementsViewThreshold
+    let graphStatsDataSource: GraphStatsDataSource
     @Binding var selectedStream: MeasurementStreamEntity?
     @StateObject var statsContainerViewModel: StatsViewModelType
-    let graphStatsDataSource: GraphStatsDataSource
     
     var body: some View {
         VStack(alignment: .trailing) {
@@ -41,6 +41,13 @@ struct ExternalGraphView<StatsViewModelType>: View where StatsViewModelType: Sta
                 }
             }
             Spacer()
+        }
+        .onAppear {
+            statsContainerViewModel.adjustForNewData()
+            statsContainerViewModel.continuousModeEnabled = true
+        }
+        .onDisappear {
+            statsContainerViewModel.continuousModeEnabled = false
         }
         .navigationBarTitleDisplayMode(.inline)
         .background(Color.aircastingBackground.ignoresSafeArea())

--- a/AirCasting/Graph/GraphView.swift
+++ b/AirCasting/Graph/GraphView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 import Resolver
 
 struct GraphView<StatsViewModelType>: View where StatsViewModelType: StatisticsContainerViewModelable {
-    
     let session: SessionEntity
     let thresholds: [SensorThreshold]
     // This pair doesn't belong here, it should be elegantly handled by VM when refactored
@@ -81,6 +80,13 @@ struct GraphView<StatsViewModelType>: View where StatsViewModelType: StatisticsC
                                                              noteNumber: selectedNote!.number,
                                                              sessionUUID: session.uuid))
         })
+        .onAppear {
+            statsContainerViewModel.adjustForNewData()
+            statsContainerViewModel.continuousModeEnabled = true
+        }
+        .onDisappear {
+            statsContainerViewModel.continuousModeEnabled = false
+        }
         .navigationBarTitleDisplayMode(.inline)
         .background(Color.aircastingBackground.ignoresSafeArea())
     }

--- a/AirCasting/Graph/StatisticsContainer/Controller/Interfaces/MeasurementsStatisticsInput.swift
+++ b/AirCasting/Graph/StatisticsContainer/Controller/Interfaces/MeasurementsStatisticsInput.swift
@@ -5,6 +5,6 @@ import Foundation
 
 protocol MeasurementsStatisticsInput {
     func computeStatistics()
-    //TODO: Comment
+    /// When continous mode is enabled it will allow for a time-based stats refreshing
     var continuousModeEnabled: Bool { get set }
 }

--- a/AirCasting/Graph/StatisticsContainer/Controller/Interfaces/MeasurementsStatisticsInput.swift
+++ b/AirCasting/Graph/StatisticsContainer/Controller/Interfaces/MeasurementsStatisticsInput.swift
@@ -5,4 +5,6 @@ import Foundation
 
 protocol MeasurementsStatisticsInput {
     func computeStatistics()
+    //TODO: Comment
+    var continuousModeEnabled: Bool { get set }
 }

--- a/AirCasting/Graph/StatisticsContainer/Controller/Interfaces/ScheduledTimer.swift
+++ b/AirCasting/Graph/StatisticsContainer/Controller/Interfaces/ScheduledTimer.swift
@@ -12,14 +12,29 @@ class ScheduledTimerSettableMock: ScheduledTimerSettable {
     
     var latestTimer: TimeInterval?
     
+    var invalidationHistory = 0
+    
     func setupRepeatingTimer(for timeInterval: TimeInterval, block: @escaping () -> Void) -> Cancellable {
         self.block = block
         self.latestTimer = timeInterval
-        return EmptyCancellable()
+        return TimerCancellableMock(timer: self)
     }
     
     func fireTimer() {
         block?()
+    }
+    
+    private class TimerCancellableMock: Cancellable {
+        func cancel() { }
+        
+        let timer: ScheduledTimerSettableMock
+        
+        init(timer: ScheduledTimerSettableMock) {
+            self.timer = timer
+        }
+        deinit {
+            timer.invalidationHistory += 1
+        }
     }
 }
 

--- a/AirCasting/Graph/StatisticsContainer/Controller/MeasurementsStatisticsController.swift
+++ b/AirCasting/Graph/StatisticsContainer/Controller/MeasurementsStatisticsController.swift
@@ -12,7 +12,6 @@ class MeasurementsStatisticsController: MeasurementsStatisticsInput {
                 Log.verbose("Continuous mode enabled, adding timer")
                 timerCancellable = scheduledTimer.setupRepeatingTimer(for: computeStatisticsInterval!, block: { [weak self] in
                     self?.computeStatistics()
-                    Log.verbose("Timer tick, computing stats")
                 })
             } else if !continuousModeEnabled {
                 Log.verbose("Continuous mode disabled, cancelling timer")

--- a/AirCasting/Graph/StatisticsContainer/ViewModel/StatisticsContainerViewModel.swift
+++ b/AirCasting/Graph/StatisticsContainer/ViewModel/StatisticsContainerViewModel.swift
@@ -5,7 +5,7 @@ import Foundation
 import SwiftUI
 
 final class StatisticsContainerViewModel: StatisticsContainerViewModelable, MeasurementsStatisticsOutput {
-    private let statsInput: MeasurementsStatisticsInput
+    private var statsInput: MeasurementsStatisticsInput
     
     init(statsInput: MeasurementsStatisticsInput) {
         self.statsInput = statsInput
@@ -13,6 +13,11 @@ final class StatisticsContainerViewModel: StatisticsContainerViewModelable, Meas
     }
     
     @Published var stats: [SingleStatViewModel] = []
+    
+    var continuousModeEnabled: Bool {
+        get { statsInput.continuousModeEnabled }
+        set { statsInput.continuousModeEnabled = newValue }
+    }
     
     func adjustForNewData() {
         statsInput.computeStatistics()

--- a/AirCasting/Graph/StatisticsContainer/ViewModel/StatisticsContainerViewModelable.swift
+++ b/AirCasting/Graph/StatisticsContainer/ViewModel/StatisticsContainerViewModelable.swift
@@ -17,7 +17,7 @@ struct SingleStatViewModel: Identifiable {
 
 protocol StatisticsContainerViewModelable: ObservableObject {
     var stats: [SingleStatViewModel] { get }
-    //TODO: Comment
+    /// When continous mode is enabled it will allow for a time-based stats refreshing
     var continuousModeEnabled: Bool { get set }
     func adjustForNewData()
 }

--- a/AirCasting/Graph/StatisticsContainer/ViewModel/StatisticsContainerViewModelable.swift
+++ b/AirCasting/Graph/StatisticsContainer/ViewModel/StatisticsContainerViewModelable.swift
@@ -17,6 +17,7 @@ struct SingleStatViewModel: Identifiable {
 
 protocol StatisticsContainerViewModelable: ObservableObject {
     var stats: [SingleStatViewModel] { get }
-    
+    //TODO: Comment
+    var continuousModeEnabled: Bool { get set }
     func adjustForNewData()
 }

--- a/AirCasting/Map/AirMapView.swift
+++ b/AirCasting/Map/AirMapView.swift
@@ -113,7 +113,13 @@ struct AirMapView: View {
         //            mapStatsDataSource.visiblePathPoints = pathPoints
         //            statsContainerViewModel.adjustForNewData()
         //        }
-        .onAppear { statsContainerViewModel.adjustForNewData() }
+        .onAppear {
+            statsContainerViewModel.adjustForNewData()
+            statsContainerViewModel.continuousModeEnabled = true
+        }
+        .onDisappear {
+            statsContainerViewModel.continuousModeEnabled = false
+        }
         .onChange(of: scenePhase) { phase in
             switch phase {
             case .background, .inactive: isUserInteracting = false

--- a/AirCasting/SessionViews/ExternalSessionsViews/ExternalSessionCard.swift
+++ b/AirCasting/SessionViews/ExternalSessionsViews/ExternalSessionCard.swift
@@ -166,9 +166,9 @@ private extension ExternalSessionCard {
     private var graphNavigationLink: some View {
         let graphView = ExternalGraphView(session: session,
                                           thresholds: ABMeasurementsViewThreshold(value: thresholds),
+                                          graphStatsDataSource: graphStatsDataSource.dataSource,
                                           selectedStream: $selectedStream,
-                                          statsContainerViewModel: graphStatsViewModel,
-                                          graphStatsDataSource: graphStatsDataSource.dataSource)
+                                          statsContainerViewModel: graphStatsViewModel)
             .foregroundColor(.aircastingDarkGray)
         
         return NavigationLink(destination: graphView,

--- a/AirCasting/SessionViews/ExternalSessionsViews/ExternalSessionCard.swift
+++ b/AirCasting/SessionViews/ExternalSessionsViews/ExternalSessionCard.swift
@@ -197,7 +197,6 @@ private extension ExternalSessionCard {
         
         let controller = MeasurementsStatisticsController(dataSource: dataSource,
                                                           calculator: StandardStatisticsCalculator(),
-                                                          scheduledTimer: ScheduledTimerSetter(),
                                                           desiredStats: MeasurementStatistics.Statistic.allCases,
                                                           computeStatisticsInterval: computeStatisticsInterval)
         let viewModel = StatisticsContainerViewModel(statsInput: controller)

--- a/AirCasting/SessionViews/ExternalSessionsViews/ExternalSessionMapView.swift
+++ b/AirCasting/SessionViews/ExternalSessionsViews/ExternalSessionMapView.swift
@@ -48,6 +48,13 @@ struct ExternalSessionMapView: View {
             }
             Spacer()
         }
+        .onAppear {
+            statsContainerViewModel.adjustForNewData()
+            statsContainerViewModel.continuousModeEnabled = true
+        }
+        .onDisappear {
+            statsContainerViewModel.continuousModeEnabled = false
+        }
         .navigationBarTitleDisplayMode(.inline)
         .padding(.bottom)
         .background(Color.aircastingBackground.ignoresSafeArea())

--- a/AirCasting/SessionViews/SessionCardView.swift
+++ b/AirCasting/SessionViews/SessionCardView.swift
@@ -224,7 +224,6 @@ private extension SessionCardView {
 
         let controller = MeasurementsStatisticsController(dataSource: dataSource,
                                                           calculator: StandardStatisticsCalculator(),
-                                                          scheduledTimer: ScheduledTimerSetter(),
                                                           desiredStats: MeasurementStatistics.Statistic.allCases,
                                                           computeStatisticsInterval: computeStatisticsInterval)
         let viewModel = StatisticsContainerViewModel(statsInput: controller)

--- a/AirCasting/SessionViews/SingleMeasurementView.swift
+++ b/AirCasting/SessionViews/SingleMeasurementView.swift
@@ -51,9 +51,9 @@ struct SingleMeasurementView: View {
                     if let threshold = threshold.value, measurementPresentationStyle == .showValues {
                         let formatter = Resolver.resolve(ThresholdFormatter.self, args: threshold)
                         HStack(spacing: 3) {
-                            if value != nil {
-                                MeasurementDotView(value: round(value!), thresholds: threshold)
-                                Text("\(Int(round(value!)))")
+                            if let value {
+                                MeasurementDotView(value: round(value), thresholds: threshold)
+                                Text("\(Int(round(value)))")
                                     .font(Fonts.moderateRegularHeading3)
                                     .foregroundColor(.aircastingGray)
                                     .scaledToFill()

--- a/AirCasting/SessionViews/SingleMeasurementView.swift
+++ b/AirCasting/SessionViews/SingleMeasurementView.swift
@@ -52,7 +52,7 @@ struct SingleMeasurementView: View {
                         let formatter = Resolver.resolve(ThresholdFormatter.self, args: threshold)
                         HStack(spacing: 3) {
                             if value != nil {
-                                MeasurementDotView(value: value!, thresholds: threshold)
+                                MeasurementDotView(value: round(value!), thresholds: threshold)
                                 Text("\(Int(round(value!)))")
                                     .font(Fonts.moderateRegularHeading3)
                                     .foregroundColor(.aircastingGray)
@@ -68,7 +68,7 @@ struct SingleMeasurementView: View {
                         .padding(.horizontal, 9)
                         .overlay(
                             RoundedRectangle(cornerRadius: 8)
-                                .strokeBorder((selectedStream == stream && value != nil) ? formatter.color(for: value!) : .clear)
+                                .strokeBorder((selectedStream == stream && value != nil) ? formatter.color(for: round(value!)) : .clear)
                         )
                     }
                 }

--- a/AirCasting/SessionViews/StatisticsContainerView.swift
+++ b/AirCasting/SessionViews/StatisticsContainerView.swift
@@ -25,9 +25,9 @@ struct StatisticsContainerView<ViewModelType>: View where ViewModelType: Statist
                 VStack(spacing: 7) {
                     Text(stat.title)
                     if stat.presentationStyle == .distinct {
-                        distinctParameter(value: stat.value)
+                        distinctParameter(value: round(stat.value))
                     } else if stat.presentationStyle == .standard {
-                        standardParameter(value: stat.value)
+                        standardParameter(value: round(stat.value))
                     }
                 }
             }

--- a/AirCasting/SessionViews/StatisticsContainerView.swift
+++ b/AirCasting/SessionViews/StatisticsContainerView.swift
@@ -90,6 +90,8 @@ struct CalculatedMeasurements_Previews: PreviewProvider {
 }
 
 class FakeStatsViewModel: StatisticsContainerViewModelable {
+    var continuousModeEnabled: Bool = false
+    
     @Published var stats: [SingleStatViewModel] = [
         .init(id: 0, title: "Low dB", value: -40.0, presentationStyle: .standard),
         .init(id: 1, title: "Now dB", value: -10.2, presentationStyle: .distinct),

--- a/AppDelegate+Injection.swift
+++ b/AppDelegate+Injection.swift
@@ -275,6 +275,10 @@ extension Resolver: ResolverRegistering {
         
         main.register { WindowAlertPresenter() as GlobalAlertPresenter }
             .scope(.application)
+        
+        // MARK: Timers
+        
+        main.register { ScheduledTimerSetter() as ScheduledTimerSettable }.scope(.application)
     }
     
     // MARK: - Composition helpers


### PR DESCRIPTION
### What was done?

Added a mechanism to suspend timers scheduled in `MeasurementsStatisticsController` so that they are not firing when the user is not in map or graph view.