### PR TITLE
Remove id from measurement entity

### DIFF
--- a/AirCasting.xcodeproj/project.pbxproj
+++ b/AirCasting.xcodeproj/project.pbxproj
@@ -624,6 +624,7 @@
 		33B397D8284FB77400C95387 /* PhotoPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPicker.swift; sourceTree = "<group>"; };
 		33BA3367266E4BCA00899343 /* MobilePeripheralSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobilePeripheralSessionManager.swift; sourceTree = "<group>"; };
 		33BA3369266E4D1000899343 /* MobileSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileSession.swift; sourceTree = "<group>"; };
+		33C9A458290ADB12003CC326 /* AirCasting v9.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "AirCasting v9.xcdatamodel"; sourceTree = "<group>"; };
 		33D07A232825963000F25B4C /* ExternalSessionEntity+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ExternalSessionEntity+CoreDataClass.swift"; sourceTree = "<group>"; };
 		33D07A242825963000F25B4C /* ExternalSessionEntity+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ExternalSessionEntity+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		33D8031528F84050004A4CFA /* SDSyncAveragingServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDSyncAveragingServiceTests.swift; sourceTree = "<group>"; };
@@ -4153,6 +4154,7 @@
 		338C30E625F10BFE00E0305C /* AirCasting.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				33C9A458290ADB12003CC326 /* AirCasting v9.xcdatamodel */,
 				FA9E08C828926C07006475D6 /* AirCasting v8.xcdatamodel */,
 				336BFBCD2857788E008D4645 /* AirCasting v7.xcdatamodel */,
 				B3620725283F97750079C052 /* AirCasting v6.xcdatamodel */,
@@ -4162,7 +4164,7 @@
 				DDF551D427985AAB009D1347 /* AirCasting v2.xcdatamodel */,
 				338C30E725F10BFE00E0305C /* AirCasting.xcdatamodel */,
 			);
-			currentVersion = FA9E08C828926C07006475D6 /* AirCasting v8.xcdatamodel */;
+			currentVersion = 33C9A458290ADB12003CC326 /* AirCasting v9.xcdatamodel */;
 			path = AirCasting.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/AirCasting/CoreData/AirCasting.xcdatamodeld/.xccurrentversion
+++ b/AirCasting/CoreData/AirCasting.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>AirCasting v8.xcdatamodel</string>
+	<string>AirCasting v9.xcdatamodel</string>
 </dict>
 </plist>

--- a/AirCasting/CoreData/AirCasting.xcdatamodeld/AirCasting v9.xcdatamodel/contents
+++ b/AirCasting/CoreData/AirCasting.xcdatamodeld/AirCasting v9.xcdatamodel/contents
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21279" systemVersion="21G83" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="BluetoothConnectionEntity" representedClassName="BluetoothConnectionEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="peripheralUUID" optional="YES" attributeType="String"/>
+        <relationship name="session" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SessionEntity" inverseName="bluetoothConnection" inverseEntity="SessionEntity"/>
+    </entity>
+    <entity name="ExternalSessionEntity" representedClassName="ExternalSessionEntity" syncable="YES">
+        <attribute name="endTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="latitude" optional="YES" attributeType="Double" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="longitude" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="provider" attributeType="String"/>
+        <attribute name="startTime" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="uuid" attributeType="String"/>
+        <relationship name="measurementStreams" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="MeasurementStreamEntity" inverseName="externalSession" inverseEntity="MeasurementStreamEntity"/>
+        <relationship name="uiState" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="UIStateEntity" inverseName="externalSession" inverseEntity="UIStateEntity"/>
+    </entity>
+    <entity name="MeasurementEntity" representedClassName="MeasurementEntity" syncable="YES">
+        <attribute name="averagingWindow" optional="YES" attributeType="Integer 64" defaultValueString="1" usesScalarValueType="YES"/>
+        <attribute name="latitude" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="longitude" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="time" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="value" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <relationship name="measurementStream" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="MeasurementStreamEntity" inverseName="measurements" inverseEntity="MeasurementStreamEntity"/>
+    </entity>
+    <entity name="MeasurementStreamEntity" representedClassName="MeasurementStreamEntity" syncable="YES">
+        <attribute name="gotDeleted" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="id" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="measurementShortType" optional="YES" attributeType="String"/>
+        <attribute name="measurementType" optional="YES" attributeType="String"/>
+        <attribute name="sensorName" optional="YES" attributeType="String"/>
+        <attribute name="sensorPackageName" optional="YES" attributeType="String"/>
+        <attribute name="thresholdHigh" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="thresholdLow" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="thresholdMedium" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="thresholdVeryHigh" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="thresholdVeryLow" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="unitName" optional="YES" attributeType="String"/>
+        <attribute name="unitSymbol" optional="YES" attributeType="String"/>
+        <relationship name="externalSession" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ExternalSessionEntity" inverseName="measurementStreams" inverseEntity="ExternalSessionEntity"/>
+        <relationship name="measurements" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="MeasurementEntity" inverseName="measurementStream" inverseEntity="MeasurementEntity"/>
+        <relationship name="session" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SessionEntity" inverseName="measurementStreams" inverseEntity="SessionEntity"/>
+    </entity>
+    <entity name="NoteEntity" representedClassName="NoteEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="lat" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="long" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="number" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="photoLocation" optional="YES" attributeType="URI"/>
+        <attribute name="text" optional="YES" attributeType="String"/>
+        <relationship name="session" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SessionEntity" inverseName="notes" inverseEntity="SessionEntity"/>
+    </entity>
+    <entity name="SensorThreshold" representedClassName="SensorThreshold" syncable="YES" codeGenerationType="class">
+        <attribute name="sensorName" attributeType="String"/>
+        <attribute name="thresholdHigh" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="thresholdLow" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="thresholdMedium" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="thresholdVeryHigh" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="thresholdVeryLow" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="SessionEntity" representedClassName="SessionEntity" syncable="YES">
+        <attribute name="changesCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="contribute" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="deviceId" optional="YES" attributeType="String"/>
+        <attribute name="deviceType" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="endTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="followedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="gotDeleted" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isIndoor" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="latitude" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="locationless" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="longitude" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="startTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="status" optional="YES" attributeType="Integer 16" defaultValueString="-1" usesScalarValueType="YES"/>
+        <attribute name="tags" optional="YES" attributeType="String"/>
+        <attribute name="type" attributeType="String"/>
+        <attribute name="urlLocation" optional="YES" attributeType="String"/>
+        <attribute name="uuid" attributeType="String"/>
+        <attribute name="version" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="bluetoothConnection" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="BluetoothConnectionEntity" inverseName="session" inverseEntity="BluetoothConnectionEntity"/>
+        <relationship name="measurementStreams" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="MeasurementStreamEntity" inverseName="session" inverseEntity="MeasurementStreamEntity"/>
+        <relationship name="notes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="NoteEntity" inverseName="session" inverseEntity="NoteEntity"/>
+        <relationship name="userInterface" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="UIStateEntity" inverseName="session" inverseEntity="UIStateEntity"/>
+    </entity>
+    <entity name="UIStateEntity" representedClassName="UIStateEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="expandedCard" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="rowOrder" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="sensorName" optional="YES" attributeType="String"/>
+        <relationship name="externalSession" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ExternalSessionEntity" inverseName="uiState" inverseEntity="ExternalSessionEntity"/>
+        <relationship name="session" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SessionEntity" inverseName="userInterface" inverseEntity="SessionEntity"/>
+    </entity>
+</model>

--- a/AirCasting/CoreData/MeasurementEntity.swift
+++ b/AirCasting/CoreData/MeasurementEntity.swift
@@ -14,11 +14,6 @@ public class MeasurementEntity: NSManagedObject, Identifiable {
     }
 
     @NSManaged public var averagingWindow: Int
-    
-    public var id: MeasurementID? {
-        get { value(forKey: "id") as? MeasurementID }
-        set { setValue(newValue, forKey: "id")}
-    }
 
     @NSManaged public var time: Date!
     @NSManaged public var value: Double

--- a/AirCasting/CoreData/NSManagedObjectContext+Utils.swift
+++ b/AirCasting/CoreData/NSManagedObjectContext+Utils.swift
@@ -90,7 +90,7 @@ extension NSManagedObjectContext {
         return nil
     }
 
-    // Checks if session/measurement exists, if not, creates a new one
+    // Checks if session/measurementStream exists, if not, creates a new one
     func newOrExisting<T: NSManagedObject & Identifiable>(id: T.ID) throws -> T  {
         let className = NSStringFromClass(T.classForCoder())
         let fetchRequest = NSFetchRequest<T>(entityName: className)

--- a/AirCasting/CoreData/PersistenceController+Database.swift
+++ b/AirCasting/CoreData/PersistenceController+Database.swift
@@ -198,7 +198,7 @@ extension Database.MeasurementStream {
                   thresholdLow: Int(coreDataEntity.thresholdLow),
                   thresholdVeryLow: Int(coreDataEntity.thresholdVeryLow),
                   measurements: coreDataEntity.allMeasurements?.map {
-                    .init(id: $0.id!, time: $0.time, value: $0.value, latitude: $0.location?.latitude, longitude: $0.location?.longitude)
+                    .init(time: $0.time, value: $0.value, latitude: $0.location?.latitude, longitude: $0.location?.longitude)
                   } ?? [],
                   deleted: coreDataEntity.gotDeleted)
     }

--- a/AirCasting/Models/Session+Mock.swift
+++ b/AirCasting/Models/Session+Mock.swift
@@ -39,7 +39,7 @@ extension MeasurementStreamEntity {
         let stream: MeasurementStreamEntity = try! context.newOrExisting(id: 1_001)
         
         for i in 0...10 {
-            let measuremennt: MeasurementEntity = try! context.newOrExisting(id: Int64(i))
+            let measuremennt: MeasurementEntity = MeasurementEntity(context: context)
             measuremennt.value = Double(arc4random() % 150)
             measuremennt.time = DateBuilder.getRawDate().addingTimeInterval(-3600).addingTimeInterval(10 * Double(i))
         }

--- a/AirCasting/Services/UpdateSessionParams.swift
+++ b/AirCasting/Services/UpdateSessionParams.swift
@@ -68,11 +68,7 @@ final class UpdateSessionParamsService {
 
             let oldMeasurements = oldStream.measurements?.array as? [MeasurementEntity] ?? []
             let measurementDiff = diff(oldMeasurements, streamOutput.measurements) {
-                if let id = $0.id {
-                    return id == $1.id
-                } else {
-                    return $0.time == $1.time && $0.value == Double($1.value)
-                }
+                return $0.time == $1.time && $0.value == Double($1.value)
             }
             measurementDiff.inserted.forEach {
                 let newMeasurement = MeasurementEntity(context: context)
@@ -114,7 +110,6 @@ private extension UpdateSessionParamsService {
         entity.value = Double(measurement.value)
         entity.location = CLLocationCoordinate2D(latitude: measurement.latitude, longitude: measurement.longitude)
         entity.time = measurement.time
-        entity.id = measurement.id
     }
 
     func fillStream(_ entity: MeasurementStreamEntity, with streamOutput: FixedSession.StreamOutput) throws {

--- a/AirCasting/SessionsSynchronization/Adapters/DataStore/SessionSynchronizationDatabase.swift
+++ b/AirCasting/SessionsSynchronization/Adapters/DataStore/SessionSynchronizationDatabase.swift
@@ -55,7 +55,7 @@ final class SessionSynchronizationDatabase: SessionSynchronizationStore {
                                                    thresholdLow: $0.thresholdLow,
                                                    thresholdVeryLow: $0.thresholdVeryLow,
                                                    measurements: $0.measurements.map {
-                                                    .init(id: $0.id, time: $0.time, value: $0.value, latitude: $0.latitude, longitude: $0.longitude)
+                                                    .init(time: $0.time, value: $0.value, latitude: $0.latitude, longitude: $0.longitude)
                                                    },
                                                    deleted: $0.deleted)
                     }

--- a/AirCasting/SessionsSynchronization/Controller/Interfaces/SessionSynchronizationStore.swift
+++ b/AirCasting/SessionsSynchronization/Controller/Interfaces/SessionSynchronizationStore.swift
@@ -77,7 +77,6 @@ extension SessionsSynchronization {
     }
     
     struct SessionStoreMeasurementData: Equatable {
-        let id: MeasurementID
         let time: Date
         let value: Double
         let latitude: Double?

--- a/AirCasting/SessionsSynchronization/Controller/Utils/SessionsSynchronizationStoreDataConverter.swift
+++ b/AirCasting/SessionsSynchronization/Controller/Utils/SessionsSynchronizationStoreDataConverter.swift
@@ -130,8 +130,7 @@ struct SynchronizationDataConverter {
                                                                              unitSymbol: stream.unitSymbol!,
                                                                              deleted: stream.deleted,
                                                                              measurements: stream.measurements.map {
-                                                                                SessionsSynchronization.SessionStoreMeasurementData(id: $0.id,
-                                                                                                                                    time: $0.time,
+                                                                                SessionsSynchronization.SessionStoreMeasurementData(time: $0.time,
                                                                                                                                     value: $0.value,
                                                                                                                                     latitude: $0.latitude,
                                                                                                                                     longitude: $0.longitude)
@@ -168,8 +167,7 @@ struct SynchronizationDataConverter {
     
     func convertDownloadDataToDatabaseStream(data: SessionsSynchronization.MeasurementStreamDownstreamData) -> SessionsSynchronization.SessionStoreMeasurementStreamData {
         let measurements: [SessionsSynchronization.SessionStoreMeasurementData] = data.measurements?.map { measurement in
-            #warning("Remove id from measurement")
-            return SessionsSynchronization.SessionStoreMeasurementData(id: .random(in: 0...Int64.max), time: measurement.time, value: measurement.value, latitude: measurement.latitude, longitude: measurement.longitude)
+            return SessionsSynchronization.SessionStoreMeasurementData(time: measurement.time, value: measurement.value, latitude: measurement.latitude, longitude: measurement.longitude)
         } ?? []
         return SessionsSynchronization.SessionStoreMeasurementStreamData(id: data.id, measurementShortType: data.measurementShortType, measurementType: data.measurementType, sensorName: data.sensorName, sensorPackageName: data.sensorPackageName, thresholdHigh: data.thresholdHigh, thresholdLow: data.thresholdLow, thresholdMedium: data.thresholdMedium, thresholdVeryHigh: data.thresholdVeryHigh, thresholdVeryLow: data.thresholdVeryLow, unitName: data.unitName, unitSymbol: data.unitSymbol, deleted: false, measurements: measurements)
     }

--- a/AirCasting/SessionsSynchronization/Database/DatabaseMeasurement.swift
+++ b/AirCasting/SessionsSynchronization/Database/DatabaseMeasurement.swift
@@ -3,20 +3,19 @@ import CoreLocation
 
 extension Database {
     public struct Measurement: Hashable {
-        public let id: MeasurementID
+//        public let id: MeasurementID
         public let time: Date
         public let value: Double
         public let latitude: Double?
         public let longitude: Double?
         
         public init(
-            id: MeasurementID,
             time: Date,
             value: Double,
             latitude: Double?,
             longitude: Double?
         ) {
-            self.id = id
+//            self.id = id
             self.time = time
             self.value = value
             self.latitude = latitude

--- a/AirCasting/SessionsSynchronization/Database/DatabaseMeasurement.swift
+++ b/AirCasting/SessionsSynchronization/Database/DatabaseMeasurement.swift
@@ -3,7 +3,6 @@ import CoreLocation
 
 extension Database {
     public struct Measurement: Hashable {
-//        public let id: MeasurementID
         public let time: Date
         public let value: Double
         public let latitude: Double?
@@ -15,7 +14,6 @@ extension Database {
             latitude: Double?,
             longitude: Double?
         ) {
-//            self.id = id
             self.time = time
             self.value = value
             self.latitude = latitude

--- a/AirCastingTests/Logic/SessionsSynchronization/SynchronizationTestMocks.swift
+++ b/AirCastingTests/Logic/SessionsSynchronization/SynchronizationTestMocks.swift
@@ -62,8 +62,7 @@ extension SessionsSynchronization.SessionStoreSessionData {
                                                                                unitSymbol: "dB",
                                                                                deleted: false,
                                                                                measurements: [
-                                                                                .init(id: 1234,
-                                                                                      time: measurementTime,
+                                                                                .init(time: measurementTime,
                                                                                       value: 12.02,
                                                                                       latitude: 51.04,
                                                                                       longitude: 50.12)

--- a/AirCastingTests/Logic/Statistics/TestStreamGenerator.swift
+++ b/AirCastingTests/Logic/Statistics/TestStreamGenerator.swift
@@ -15,7 +15,6 @@ enum TestStreamGenerator {
         let stream = MeasurementStreamEntity(context: persistence.viewContext)
         for index in 0..<numberOfMeasurements {
             let entity = MeasurementEntity(context: persistence.viewContext)
-            entity.id = Int64(index)
             entity.value = 0.0 + Double(index)
             entity.location = CLLocationCoordinate2D(latitude: CLLocationDegrees(index), longitude: CLLocationDegrees(index))
             entity.time = DateBuilder.getDateWithTimeIntervalSince1970(Double(index))

--- a/AirCastingTests/Model/UpdateSessionParamsServiceTests.swift
+++ b/AirCastingTests/Model/UpdateSessionParamsServiceTests.swift
@@ -133,7 +133,6 @@ final class UpdateSessionParamsServiceTests: ACTestCase {
             let measurements = try XCTUnwrap(databaseMeasurementStream.measurements?.array as? [AirCasting.MeasurementEntity])
             XCTAssertEqual(measurements.count, modelMeasurementStream.measurements.count)
             try zip(measurements, modelMeasurementStream.measurements).forEach { databaseMeasurement, modelMeasurement in
-                XCTAssertEqual(databaseMeasurement.id, modelMeasurement.id)
                 XCTAssertEqual(databaseMeasurement.value, modelMeasurement.measured_value)
                 XCTAssertEqual(try XCTUnwrap(databaseMeasurement.location).latitude, modelMeasurement.latitude, accuracy: 0.01)
                 XCTAssertEqual(try XCTUnwrap(databaseMeasurement.location).longitude, modelMeasurement.longitude, accuracy: 0.01)

--- a/FixedSessionFaker.swift
+++ b/FixedSessionFaker.swift
@@ -53,17 +53,14 @@ class FixedSessionFaker {
 
             try! context.save()
         }
-
-        var currId: Int64 = 1
+        
         Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
-            for stream in session.allStreams ?? [] {
+            for stream in session.allStreams {
                 let measurement = MeasurementEntity(context: context)
-                measurement.id = currId
                 measurement.time = DateBuilder.getRawDate()
                 measurement.value = .random(in: 0...120)
                 measurement.location = .init(latitude: 50.049683, longitude: 19.944544)
                 stream.addToMeasurements(measurement)
-                currId += 1
             }
             try! context.save()
         }


### PR DESCRIPTION
### What was done?

MeasurementEntity had an `id` attribute, which was never used for anything, so it gets deleted.