### PR TITLE
Show measurements downloading progress in following tab

### DIFF
--- a/AirCasting/CoreData/NSManagedObjectContext+Utils.swift
+++ b/AirCasting/CoreData/NSManagedObjectContext+Utils.swift
@@ -23,7 +23,7 @@ extension NSManagedObjectContext {
                                     NSDate(timeIntervalSince1970: thresholdInSeconds), stream)
         do {
             let measurements = try self.fetch(req)
-            measurements.forEach { Log.info("Removing measurement: \($0)"); self.delete($0) }
+            measurements.forEach { Log.info("Removing measurement for stream: \($0.measurementStream.sensorName ?? "no name") from \(String(describing: $0.time))"); self.delete($0) }
             try! self.save()
         } catch {
             throw error

--- a/AirCasting/Dashboard/DashboardView.swift
+++ b/AirCasting/Dashboard/DashboardView.swift
@@ -18,6 +18,7 @@ struct DashboardView: View {
     @EnvironmentObject var reorderButton: ReorderButton
     @EnvironmentObject var searchAndFollowButton: SearchAndFollowButton
     @State var isRefreshing: Bool
+    @Binding var measurementsDownloadingInProgress: Bool
     @State private var alert: AlertInfo?
     @InjectedObject private var userSettings: UserSettings
     @Injected private var networkChecker: NetworkChecker
@@ -28,12 +29,13 @@ struct DashboardView: View {
         coreDataHook.sessions
     }
 
-    init(coreDataHook: CoreDataHook) {
+    init(coreDataHook: CoreDataHook, measurementsDownloadingInProgress: Binding<Bool>) {
         let navBarAppearance = UINavigationBar.appearance()
         navBarAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor(Color.darkBlue)]
         _coreDataHook = StateObject(wrappedValue: coreDataHook)
         self.sessionSynchronizer = Resolver.resolve(SessionSynchronizer.self)
         _isRefreshing = .init(wrappedValue: sessionSynchronizer.syncInProgress.value)
+        _measurementsDownloadingInProgress = .init(projectedValue: measurementsDownloadingInProgress)
     }
 
     var body: some View {
@@ -48,7 +50,7 @@ struct DashboardView: View {
                 sessionTypePicker
                 TabView(selection: $selectedSection.section) {
                     ForEach(DashboardSection.allCases, id: \.self) {
-                        SessionsListView(selectedSection: $0, isRefreshing: $isRefreshing, context: persistenceController.viewContext)
+                        SessionsListView(selectedSection: $0, isRefreshing: $isRefreshing, isDownloading: $measurementsDownloadingInProgress, context: persistenceController.viewContext)
                     }
                 }
                 .tabViewStyle(.page(indexDisplayMode: .never))

--- a/AirCasting/Dashboard/DashboardView.swift
+++ b/AirCasting/Dashboard/DashboardView.swift
@@ -36,6 +36,8 @@ struct DashboardView: View {
         self.sessionSynchronizer = Resolver.resolve(SessionSynchronizer.self)
         _isRefreshing = .init(wrappedValue: sessionSynchronizer.syncInProgress.value)
         _measurementsDownloadingInProgress = .init(projectedValue: measurementsDownloadingInProgress)
+        var log = isRefreshing
+        Log.info("##### IS REFRESHING: \(log)")
     }
 
     var body: some View {
@@ -50,7 +52,7 @@ struct DashboardView: View {
                 sessionTypePicker
                 TabView(selection: $selectedSection.section) {
                     ForEach(DashboardSection.allCases, id: \.self) {
-                        SessionsListView(selectedSection: $0, isRefreshing: $isRefreshing, isDownloading: $measurementsDownloadingInProgress, context: persistenceController.viewContext)
+                        SessionsListView(selectedSection: $0, isRefreshing: $isRefreshing, measurementsDownloadingInProgress: $measurementsDownloadingInProgress, context: persistenceController.viewContext)
                     }
                 }
                 .tabViewStyle(.page(indexDisplayMode: .never))

--- a/AirCasting/Dashboard/DashboardView.swift
+++ b/AirCasting/Dashboard/DashboardView.swift
@@ -36,8 +36,6 @@ struct DashboardView: View {
         self.sessionSynchronizer = Resolver.resolve(SessionSynchronizer.self)
         _isRefreshing = .init(wrappedValue: sessionSynchronizer.syncInProgress.value)
         _measurementsDownloadingInProgress = .init(projectedValue: measurementsDownloadingInProgress)
-        var log = isRefreshing
-        Log.info("##### IS REFRESHING: \(log)")
     }
 
     var body: some View {

--- a/AirCasting/Dashboard/RefreshControl.swift
+++ b/AirCasting/Dashboard/RefreshControl.swift
@@ -15,7 +15,7 @@ struct RefreshControl: View {
                 startRefreshing()
             }
             ZStack(alignment: .center) {
-                if isRefreshing { ProgressView(Strings.RefreshControl.progressViewTest) } else { mimicPullToRefreshAnimation(with: geometry) }
+                if isRefreshing { ProgressView(Strings.RefreshControl.progressViewText) } else { mimicPullToRefreshAnimation(with: geometry) }
             }
             .frame(width: geometry.size.width)
         }

--- a/AirCasting/Dashboard/Reordering/ReorderingDashboard.swift
+++ b/AirCasting/Dashboard/Reordering/ReorderingDashboard.swift
@@ -18,7 +18,7 @@ struct ReorderingDashboard: View {
     var body: some View {
         ScrollView {
             LazyVGrid(columns: columns) {
-                ForEach(viewModel.sessions, id: \.uuid) { session in
+                ForEach(viewModel.sessions.filter { $0.uuid != "" && !$0.gotDeleted }, id: \.uuid) { session in
                     ReoredringSessionCard(session: session, thresholds: viewModel.thresholds)
                         .overlay(viewModel.currentlyDraggedSession?.uuid == session.uuid && changedView ? Color.aircastingWhite.opacity(0.8) : Color.clear)
                         .onDrag({

--- a/AirCasting/Dashboard/Reordering/ReorderingDashboard.swift
+++ b/AirCasting/Dashboard/Reordering/ReorderingDashboard.swift
@@ -18,7 +18,7 @@ struct ReorderingDashboard: View {
     var body: some View {
         ScrollView {
             LazyVGrid(columns: columns) {
-                ForEach(viewModel.sessions.filter { $0.uuid != "" && !$0.gotDeleted }, id: \.uuid) { session in
+                ForEach(viewModel.sessions, id: \.uuid) { session in
                     ReoredringSessionCard(session: session, thresholds: viewModel.thresholds)
                         .overlay(viewModel.currentlyDraggedSession?.uuid == session.uuid && changedView ? Color.aircastingWhite.opacity(0.8) : Color.clear)
                         .onDrag({

--- a/AirCasting/Dashboard/Reordering/ReorderingDashboardViewModel.swift
+++ b/AirCasting/Dashboard/Reordering/ReorderingDashboardViewModel.swift
@@ -14,7 +14,7 @@ class ReorderingDashboardViewModel: ObservableObject {
     @Injected private var measurementStreamStorage: MeasurementStreamStorage
     
     init(sessions: [Sessionable], thresholds: [SensorThreshold]) {
-        self.sessions = sessions
+        self.sessions = sessions.filter { $0.uuid != "" && !$0.gotDeleted }
         self.thresholds = thresholds
     }
     

--- a/AirCasting/Dashboard/SessionListView.swift
+++ b/AirCasting/Dashboard/SessionListView.swift
@@ -14,16 +14,16 @@ struct SessionsListView: View {
     @FetchRequest<SensorThreshold>(sortDescriptors: [.init(key: "sensorName", ascending: true)]) private var thresholds
     @StateObject private var coreDataHook: CoreDataHook
     @Binding private var isRefreshing: Bool
-    @Binding private var isDownloading: Bool
+    @Binding private var measurementsDownloadingInProgress: Bool
     @InjectedObject private var featureFlagsViewModel: FeatureFlagsViewModel
     
     private let listCoordinateSpaceName = "listCoordinateSpace"
     private let selectedSection: DashboardSection
 
-    init(selectedSection: DashboardSection, isRefreshing: Binding<Bool>, isDownloading: Binding<Bool>, context: NSManagedObjectContext) {
+    init(selectedSection: DashboardSection, isRefreshing: Binding<Bool>, measurementsDownloadingInProgress: Binding<Bool>, context: NSManagedObjectContext) {
         self.selectedSection = selectedSection
         _isRefreshing = .init(projectedValue: isRefreshing)
-        _isDownloading = .init(projectedValue: isDownloading)
+        _measurementsDownloadingInProgress = .init(projectedValue: measurementsDownloadingInProgress)
         _coreDataHook = .init(wrappedValue: .init(context: context))
     }
     
@@ -46,7 +46,7 @@ struct SessionsListView: View {
                 if selectedSection.allowsRefreshing {
                     RefreshControl(coordinateSpace: .named(listCoordinateSpaceName), isRefreshing: $isRefreshing)
                 }
-                if selectedSection == .following && isDownloading {
+                if selectedSection.shouldShowMeasurementDownloadProgress && measurementsDownloadingInProgress {
                     ProgressView(Strings.SessionListView.downloading)
                         .padding(.top)
                 }

--- a/AirCasting/Dashboard/SessionListView.swift
+++ b/AirCasting/Dashboard/SessionListView.swift
@@ -14,14 +14,16 @@ struct SessionsListView: View {
     @FetchRequest<SensorThreshold>(sortDescriptors: [.init(key: "sensorName", ascending: true)]) private var thresholds
     @StateObject private var coreDataHook: CoreDataHook
     @Binding private var isRefreshing: Bool
+    @Binding private var isDownloading: Bool
     @InjectedObject private var featureFlagsViewModel: FeatureFlagsViewModel
     
     private let listCoordinateSpaceName = "listCoordinateSpace"
     private let selectedSection: DashboardSection
 
-    init(selectedSection: DashboardSection, isRefreshing: Binding<Bool>, context: NSManagedObjectContext) {
+    init(selectedSection: DashboardSection, isRefreshing: Binding<Bool>, isDownloading: Binding<Bool>, context: NSManagedObjectContext) {
         self.selectedSection = selectedSection
         _isRefreshing = .init(projectedValue: isRefreshing)
+        _isDownloading = .init(projectedValue: isDownloading)
         _coreDataHook = .init(wrappedValue: .init(context: context))
     }
     
@@ -43,6 +45,10 @@ struct SessionsListView: View {
             ScrollView {
                 if selectedSection.allowsRefreshing {
                     RefreshControl(coordinateSpace: .named(listCoordinateSpaceName), isRefreshing: $isRefreshing)
+                }
+                if selectedSection == .following && isDownloading {
+                    ProgressView(Strings.SessionListView.downloading)
+                        .padding(.top)
                 }
                 LazyVStack(spacing: 8) {
                     ForEach(coreDataHook.sessions.filter { $0.uuid != "" && !$0.gotDeleted }, id: \.uuid) { session in

--- a/AirCasting/MainTabBarView.swift
+++ b/AirCasting/MainTabBarView.swift
@@ -25,6 +25,7 @@ struct MainTabBarView: View {
     @StateObject var coreDataHook: CoreDataHook
     @InjectedObject private var featureFlagsViewModel: FeatureFlagsViewModel
     @Environment(\.colorScheme) var colorScheme
+    @State var measurementsDownloadingInProgress = false
     
     private var sessions: [Sessionable] {
         coreDataHook.sessions
@@ -54,7 +55,8 @@ struct MainTabBarView: View {
             
         }
         .onAppCameToForeground {
-            measurementUpdatingService.updateAllSessionsMeasurements()
+            measurementsDownloadingInProgress = true
+            measurementUpdatingService.updateAllSessionsMeasurements() { measurementsDownloadingInProgress = false }
         }
         .onAppear {
             UITabBar.appearance().backgroundColor = .aircastingBackground
@@ -62,6 +64,8 @@ struct MainTabBarView: View {
             appearance.backgroundImage = UIImage()
             appearance.shadowImage = UIImage.mainTabBarShadow
             UITabBar.appearance().standardAppearance = appearance
+            measurementsDownloadingInProgress = true
+            measurementUpdatingService.updateAllSessionsMeasurements() { measurementsDownloadingInProgress = false }
             measurementUpdatingService.start()
         }
         .onChange(of: tabSelection.selection, perform: { _ in
@@ -84,7 +88,7 @@ private extension MainTabBarView {
     // Tab Bar views
     private var dashboardTab: some View {
         NavigationView {
-            DashboardView(coreDataHook: coreDataHook)
+            DashboardView(coreDataHook: coreDataHook, measurementsDownloadingInProgress: $measurementsDownloadingInProgress)
         }.navigationViewStyle(StackNavigationViewStyle())
             .tabItem {
                 createTabBarImage(homeImage)

--- a/AirCasting/MainTabBarView.swift
+++ b/AirCasting/MainTabBarView.swift
@@ -56,7 +56,11 @@ struct MainTabBarView: View {
         }
         .onAppCameToForeground {
             measurementsDownloadingInProgress = true
-            measurementUpdatingService.updateAllSessionsMeasurements() { measurementsDownloadingInProgress = false }
+            measurementUpdatingService.updateAllSessionsMeasurements() {
+                DispatchQueue.main.async {
+                    measurementsDownloadingInProgress = false
+                }
+            }
         }
         .onAppear {
             UITabBar.appearance().backgroundColor = .aircastingBackground
@@ -65,7 +69,11 @@ struct MainTabBarView: View {
             appearance.shadowImage = UIImage.mainTabBarShadow
             UITabBar.appearance().standardAppearance = appearance
             measurementsDownloadingInProgress = true
-            measurementUpdatingService.updateAllSessionsMeasurements() { measurementsDownloadingInProgress = false }
+            measurementUpdatingService.updateAllSessionsMeasurements() {
+                DispatchQueue.main.async {
+                    measurementsDownloadingInProgress = false
+                }
+            }
             measurementUpdatingService.start()
         }
         .onChange(of: tabSelection.selection, perform: { _ in
@@ -214,6 +222,13 @@ enum DashboardSection: String, CaseIterable {
         switch self {
         case .fixed, .mobileDormant: return true
         case .following, .mobileActive: return false
+        }
+    }
+    
+    var shouldShowMeasurementDownloadProgress: Bool {
+        switch self {
+        case .following: return true
+        case .mobileDormant, .mobileActive, .fixed: return false
         }
     }
 }

--- a/AirCasting/Services/DownloadMeasurmentsService.swift
+++ b/AirCasting/Services/DownloadMeasurmentsService.swift
@@ -121,13 +121,13 @@ final class DownloadMeasurementsService: MeasurementUpdatingService {
         let context = persistenceController.editContext
         context.perform {
             do {
+                defer { completion() }
                 if !isExternal {
                     Log.info("Processing regular session response")
                     let session: SessionEntity = try context.newOrExisting(uuid: output.uuid)
                     try UpdateSessionParamsService().updateSessionsParams(session: session, output: output)
                     try self.removeOldServiceDefault.removeOldestMeasurements(in: context,
                                                                        from: sessionUUID)
-                    completion()
                 } else {
                     Log.info("Processing external session response")
                     let session = try context.existingExternalSession(uuid: sessionUUID)
@@ -145,18 +145,14 @@ final class DownloadMeasurementsService: MeasurementUpdatingService {
                     })
                     try self.removeOldServiceDefault.removeOldestMeasurements(in: context,
                                                                               from: sessionUUID)
-                    completion()
                 }
                 try context.save()
             } catch let error as UpdateSessionParamsService.Error {
                 Log.error("Failed to update session params: \(error)")
-                completion()
             } catch let error as DefaultRemoveOldMeasurementsService.Error {
                 Log.error("Failed to remove old measaurements from fixed session \(error)")
-                completion()
             } catch {
                 Log.error("Save error: \(error)")
-                completion()
             }
         }
     }

--- a/AirCasting/Utils/Strings.swift
+++ b/AirCasting/Utils/Strings.swift
@@ -799,12 +799,17 @@ struct Strings {
         static let following: String = NSLocalizedString("Following", comment: "")
     }
     
+    enum SessionListView {
+        static let downloading: String = NSLocalizedString("Downloading...",
+                                                             comment: "")
+    }
+    
     enum Chart {
         static let emptyChartMessage = NSLocalizedString("Waiting for the first average value", comment: "")
     }
 
     enum RefreshControl {
-        static let progressViewTest: String = NSLocalizedString("Syncing...",
+        static let progressViewText: String = NSLocalizedString("Syncing...",
                                                                 comment: "")
     }
     


### PR DESCRIPTION
https://trello.com/c/JJclGtOq

We want to show progress view when we are downloading measurements for followed session when user enters the app, because sometimes it can take a significant time.

### Additional change
I noticed that in reordering dashboard we are showing a card for deleted session so that got fixed as well