### PR TITLE
Make sure there can be only one session being recorded

### DIFF
--- a/AirCasting/CreateSessionViews/ConfirmCreatingSessionView.swift
+++ b/AirCasting/CreateSessionViews/ConfirmCreatingSessionView.swift
@@ -125,7 +125,8 @@ struct ConfirmCreatingSessionView: View {
                     Text(Strings.ConfirmCreatingSessionView.startRecording)
                         .font(Fonts.muliBoldHeading1)
                 })
-                    .buttonStyle(BlueButtonStyle())
+                .buttonStyle(BlueButtonStyle())
+                .disabled(isActive)
             }
             .padding()
         }


### PR DESCRIPTION
Adding one more check because when the phone freezes on session creation confirmation screen and a user presses a button more than once it is possible that more than one session is created