### PR TITLE
Show refresh control when sync was trigerred from code.

### DIFF
--- a/AirCasting/Dashboard/DashboardView.swift
+++ b/AirCasting/Dashboard/DashboardView.swift
@@ -28,6 +28,10 @@ struct DashboardView: View {
     private var sessions: [Sessionable] {
         coreDataHook.sessions
     }
+    
+    private var noDormantNorFixedSessions: Bool {
+        !sessions.contains(where: { $0.isFixed || !$0.isActive })
+    }
 
     init(coreDataHook: CoreDataHook, measurementsDownloadingInProgress: Binding<Bool>) {
         let navBarAppearance = UINavigationBar.appearance()
@@ -65,8 +69,8 @@ struct DashboardView: View {
         .navigationBarHidden(true)
         .onReceive(sessionSynchronizer.syncInProgress, perform: { value in
             // Aim of this, is to show the sync spinner
-            // whenever sync will be triggered from the code.
-            guard value == true, isRefreshing != true else { return }
+            // whenever sync will be triggered from the code and no session is presented on screen.
+            guard value == true, isRefreshing != true, noDormantNorFixedSessions else { return }
             isRefreshing = value
         })
         .onChange(of: isRefreshing, perform: { newValue in

--- a/AirCasting/Dashboard/DashboardView.swift
+++ b/AirCasting/Dashboard/DashboardView.swift
@@ -63,6 +63,12 @@ struct DashboardView: View {
         }
         .navigationBarTitle(Strings.DashboardView.dashboardText)
         .navigationBarHidden(true)
+        .onReceive(sessionSynchronizer.syncInProgress, perform: { value in
+            // Aim of this, is to show the sync spinner
+            // whenever sync will be triggered from the code.
+            guard value == true, isRefreshing != true else { return }
+            isRefreshing = value
+        })
         .onChange(of: isRefreshing, perform: { newValue in
             guard newValue == true else { return }
             guard !sessionSynchronizer.syncInProgress.value else {


### PR DESCRIPTION
**Goal:**
Now, when user logs in to the app, there is no indication of sync from the UI perspective.
Goal was to add this spinner, and cover possible future cases when sync could be triggered from code.