### PR TITLE
Unless there are no streams, show alert.

### DIFF
--- a/AirCasting/Utils/InAppAlerts.swift
+++ b/AirCasting/Utils/InAppAlerts.swift
@@ -111,6 +111,15 @@ struct InAppAlerts {
                   ])
     }
     
+    static func noStreamsAlert() -> AlertInfo {
+        AlertInfo(title: Strings.SessionShare.noStreamsTitle,
+                  message: Strings.SessionShare.noStreamsMessage,
+                  buttons: [
+                    .default(title: Strings.Commons.gotIt,
+                             action: nil)
+                  ])
+    }
+    
     static func shareFileRequestSent() -> AlertInfo {
         AlertInfo(
             title: Strings.SessionHeaderView.shareFileAlertTitle,

--- a/AirCasting/Utils/Strings.swift
+++ b/AirCasting/Utils/Strings.swift
@@ -168,6 +168,10 @@ struct Strings {
                                                                      comment: "")
         static let linkSharingAlertMessage: String = NSLocalizedString("Try again later",
                                                                        comment: "")
+        static let noStreamsTitle: String = NSLocalizedString("No streams available",
+                                                              comment: "")
+        static let noStreamsMessage: String = NSLocalizedString("Please, try again once streams show up.",
+                                                              comment: "")
         static let emailSharingAlertTitle: String = NSLocalizedString("Request failed",
                                                                       comment: "")
         static let emailSharingAlertMessage: String = NSLocalizedString("Please try again later",


### PR DESCRIPTION
The aim was not to allow users to get a link when sharing a fixed session which is gathering data and no stream can be seen.