### PR TITLE
Fix end time updating for active session

### DIFF
--- a/AirCasting.xcodeproj/project.pbxproj
+++ b/AirCasting.xcodeproj/project.pbxproj
@@ -33,7 +33,7 @@
 		3320F30329269A5400EFFB2D /* SessionManagingReconnectionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3320F30229269A5400EFFB2D /* SessionManagingReconnectionControllerTests.swift */; };
 		3320F30929269AB000EFFB2D /* MobileAirBeamSessionRecordingControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3320F30829269AB000EFFB2D /* MobileAirBeamSessionRecordingControllerTests.swift */; };
 		3320F3102927E32100EFFB2D /* MobileSessionStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3320F30F2927E32100EFFB2D /* MobileSessionStorage.swift */; };
-		332B994B293A427B00C0D15D /* SessionTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332B994A293A427B00C0D15D /* SessionTime.swift */; };
+		332B994B293A427B00C0D15D /* SessionTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332B994A293A427B00C0D15D /* SessionTimeView.swift */; };
 		332F521425FA38430047236D /* MicrophoneManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332F521325FA38430047236D /* MicrophoneManager.swift */; };
 		334062442816B4B6004DA4DA /* EditLocationlessSessionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334062432816B4B6004DA4DA /* EditLocationlessSessionViewModel.swift */; };
 		33406247281821FA004DA4DA /* ExternalSessionsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33406246281821FA004DA4DA /* ExternalSessionsStore.swift */; };
@@ -610,7 +610,7 @@
 		3320F30229269A5400EFFB2D /* SessionManagingReconnectionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManagingReconnectionControllerTests.swift; sourceTree = "<group>"; };
 		3320F30829269AB000EFFB2D /* MobileAirBeamSessionRecordingControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileAirBeamSessionRecordingControllerTests.swift; sourceTree = "<group>"; };
 		3320F30F2927E32100EFFB2D /* MobileSessionStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileSessionStorage.swift; sourceTree = "<group>"; };
-		332B994A293A427B00C0D15D /* SessionTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTime.swift; sourceTree = "<group>"; };
+		332B994A293A427B00C0D15D /* SessionTimeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTimeView.swift; sourceTree = "<group>"; };
 		332F521325FA38430047236D /* MicrophoneManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrophoneManager.swift; sourceTree = "<group>"; };
 		334062432816B4B6004DA4DA /* EditLocationlessSessionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditLocationlessSessionViewModel.swift; sourceTree = "<group>"; };
 		3340624528181376004DA4DA /* AirCasting v5.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "AirCasting v5.xcdatamodel"; sourceTree = "<group>"; };
@@ -1674,7 +1674,7 @@
 				AC9EB64326ECB0C000B1F780 /* SessionCartViewModel */,
 				DDEE3A492697473C0098CCA9 /* EditSessionButton */,
 				3328F11E266786C600B72D61 /* Chart */,
-				332B994A293A427B00C0D15D /* SessionTime.swift */,
+				332B994A293A427B00C0D15D /* SessionTimeView.swift */,
 			);
 			path = SessionViews;
 			sourceTree = "<group>";
@@ -3532,7 +3532,7 @@
 				AC6D569F25AEEAE700D221BA /* SessionHeaderView.swift in Sources */,
 				B3AB8BE526BB5EF400AF23CC /* Array+MeasurementStatistics.swift in Sources */,
 				FAF3B4E128057EC100F0F4B0 /* MeasurementType.swift in Sources */,
-				332B994B293A427B00C0D15D /* SessionTime.swift in Sources */,
+				332B994B293A427B00C0D15D /* SessionTimeView.swift in Sources */,
 				334EF27E28E5CE7E000DD51E /* SDSyncMobileSessionStorage.swift in Sources */,
 				B3C3F8B92695A295003E2CB4 /* StatisticsContainerViewModelable.swift in Sources */,
 				AC32040425CC067D00A68520 /* CheckBox.swift in Sources */,

--- a/AirCasting.xcodeproj/project.pbxproj
+++ b/AirCasting.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		3320F30329269A5400EFFB2D /* SessionManagingReconnectionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3320F30229269A5400EFFB2D /* SessionManagingReconnectionControllerTests.swift */; };
 		3320F30929269AB000EFFB2D /* MobileAirBeamSessionRecordingControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3320F30829269AB000EFFB2D /* MobileAirBeamSessionRecordingControllerTests.swift */; };
 		3320F3102927E32100EFFB2D /* MobileSessionStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3320F30F2927E32100EFFB2D /* MobileSessionStorage.swift */; };
+		332B994B293A427B00C0D15D /* SessionTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332B994A293A427B00C0D15D /* SessionTime.swift */; };
 		332F521425FA38430047236D /* MicrophoneManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332F521325FA38430047236D /* MicrophoneManager.swift */; };
 		334062442816B4B6004DA4DA /* EditLocationlessSessionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334062432816B4B6004DA4DA /* EditLocationlessSessionViewModel.swift */; };
 		33406247281821FA004DA4DA /* ExternalSessionsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33406246281821FA004DA4DA /* ExternalSessionsStore.swift */; };
@@ -609,6 +610,7 @@
 		3320F30229269A5400EFFB2D /* SessionManagingReconnectionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManagingReconnectionControllerTests.swift; sourceTree = "<group>"; };
 		3320F30829269AB000EFFB2D /* MobileAirBeamSessionRecordingControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileAirBeamSessionRecordingControllerTests.swift; sourceTree = "<group>"; };
 		3320F30F2927E32100EFFB2D /* MobileSessionStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileSessionStorage.swift; sourceTree = "<group>"; };
+		332B994A293A427B00C0D15D /* SessionTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTime.swift; sourceTree = "<group>"; };
 		332F521325FA38430047236D /* MicrophoneManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrophoneManager.swift; sourceTree = "<group>"; };
 		334062432816B4B6004DA4DA /* EditLocationlessSessionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditLocationlessSessionViewModel.swift; sourceTree = "<group>"; };
 		3340624528181376004DA4DA /* AirCasting v5.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "AirCasting v5.xcdatamodel"; sourceTree = "<group>"; };
@@ -1672,6 +1674,7 @@
 				AC9EB64326ECB0C000B1F780 /* SessionCartViewModel */,
 				DDEE3A492697473C0098CCA9 /* EditSessionButton */,
 				3328F11E266786C600B72D61 /* Chart */,
+				332B994A293A427B00C0D15D /* SessionTime.swift */,
 			);
 			path = SessionViews;
 			sourceTree = "<group>";
@@ -3529,6 +3532,7 @@
 				AC6D569F25AEEAE700D221BA /* SessionHeaderView.swift in Sources */,
 				B3AB8BE526BB5EF400AF23CC /* Array+MeasurementStatistics.swift in Sources */,
 				FAF3B4E128057EC100F0F4B0 /* MeasurementType.swift in Sources */,
+				332B994B293A427B00C0D15D /* SessionTime.swift in Sources */,
 				334EF27E28E5CE7E000DD51E /* SDSyncMobileSessionStorage.swift in Sources */,
 				B3C3F8B92695A295003E2CB4 /* StatisticsContainerViewModelable.swift in Sources */,
 				AC32040425CC067D00A68520 /* CheckBox.swift in Sources */,

--- a/AirCasting/SessionViews/SessionHeaderView.swift
+++ b/AirCasting/SessionViews/SessionHeaderView.swift
@@ -124,7 +124,7 @@ private extension SessionHeaderView {
     var sessionHeader: some View {
         VStack(alignment: .leading, spacing: 3) {
             HStack {
-                dateAndTime
+                SessionTime(session: session)
                     .font(Fonts.moderateRegularHeading4)
                     .foregroundColor(Color.aircastingTimeGray)
                 Spacer()
@@ -134,10 +134,6 @@ private extension SessionHeaderView {
         }
         .alert(item: $alert, content: { $0.makeAlert() })
         .foregroundColor(.aircastingGray)
-    }
-
-    var dateAndTime: some View {
-        adaptTimeAndDate()
     }
     
     var nameLabelAndExpandButton: some View {
@@ -264,15 +260,6 @@ private extension SessionHeaderView {
     
     var thresholdAlertSheet: some View {
         ThresholdAlertSheet(session: session, isActive: $showThresholdAlertModal)
-    }
-
-    func adaptTimeAndDate() -> Text {
-        let formatter: DateIntervalFormatter = DateFormatters.SessionCardView.shared.utcDateIntervalFormatter
-        guard let start = session.startTime else { return Text("") }
-        let end = session.endTime ?? DateBuilder.getFakeUTCDate()
-        
-        let string = formatter.string(from: start, to: end)
-        return Text(string)
     }
     
     private func finishSessionAlertAction() {

--- a/AirCasting/SessionViews/SessionHeaderView.swift
+++ b/AirCasting/SessionViews/SessionHeaderView.swift
@@ -124,7 +124,7 @@ private extension SessionHeaderView {
     var sessionHeader: some View {
         VStack(alignment: .leading, spacing: 3) {
             HStack {
-                SessionTime(session: session)
+                SessionTimeView(session: session)
                     .font(Fonts.moderateRegularHeading4)
                     .foregroundColor(Color.aircastingTimeGray)
                 Spacer()

--- a/AirCasting/SessionViews/SessionTime.swift
+++ b/AirCasting/SessionViews/SessionTime.swift
@@ -1,0 +1,48 @@
+// Created by Lunar on 02/12/2022.
+//
+
+import Foundation
+import SwiftUI
+
+struct SessionTime: View {
+    @ObservedObject var session: SessionEntity
+    
+    private var sessionStreams: [MeasurementStreamEntity] {
+        return session.sortedStreams
+    }
+    
+    var body: some View {
+        if session.isActive, let stream = sessionStreams.first {
+            DynamicSessionTime(session: session, stream: stream)
+        } else {
+            staticTimeAndDate()
+        }
+    }
+    
+    func staticTimeAndDate() -> Text {
+        let formatter: DateIntervalFormatter = DateFormatters.SessionCardView.shared.utcDateIntervalFormatter
+        guard let start = session.startTime else { return Text("") }
+        let end = session.endTime ?? DateBuilder.getFakeUTCDate()
+        
+        let string = formatter.string(from: start, to: end)
+        return Text(string)
+    }
+}
+
+struct DynamicSessionTime: View {
+    @ObservedObject var session: SessionEntity
+    @ObservedObject var stream: MeasurementStreamEntity
+    
+    var body: some View {
+        Text(formatedTimeAndDate())
+    }
+    
+    func formatedTimeAndDate() -> String {
+        let formatter: DateIntervalFormatter = DateFormatters.SessionCardView.shared.utcDateIntervalFormatter
+        guard let start = session.startTime else { return "" }
+        let end = session.endTime ?? stream.lastMeasurementTime ?? DateBuilder.getFakeUTCDate()
+        
+        let string = formatter.string(from: start, to: end)
+        return string
+    }
+}

--- a/AirCasting/SessionViews/SessionTime.swift
+++ b/AirCasting/SessionViews/SessionTime.swift
@@ -15,34 +15,34 @@ struct SessionTime: View {
         if session.isActive, let stream = sessionStreams.first {
             DynamicSessionTime(session: session, stream: stream)
         } else {
-            staticTimeAndDate()
+            Text(staticTimeAndDate())
         }
     }
     
-    func staticTimeAndDate() -> Text {
+    func staticTimeAndDate() -> String {
         let formatter: DateIntervalFormatter = DateFormatters.SessionCardView.shared.utcDateIntervalFormatter
-        guard let start = session.startTime else { return Text("") }
+        guard let start = session.startTime else { return "" }
         let end = session.endTime ?? DateBuilder.getFakeUTCDate()
         
         let string = formatter.string(from: start, to: end)
-        return Text(string)
-    }
-}
-
-struct DynamicSessionTime: View {
-    @ObservedObject var session: SessionEntity
-    @ObservedObject var stream: MeasurementStreamEntity
-    
-    var body: some View {
-        Text(formatedTimeAndDate())
-    }
-    
-    func formatedTimeAndDate() -> String {
-        let formatter: DateIntervalFormatter = DateFormatters.SessionCardView.shared.utcDateIntervalFormatter
-        guard let start = session.startTime else { return "" }
-        let end = session.endTime ?? stream.lastMeasurementTime ?? DateBuilder.getFakeUTCDate()
-        
-        let string = formatter.string(from: start, to: end)
         return string
+    }
+    
+    private struct DynamicSessionTime: View {
+        @ObservedObject var session: SessionEntity
+        @ObservedObject var stream: MeasurementStreamEntity
+        
+        var body: some View {
+            Text(formatedTimeAndDate())
+        }
+        
+        func formatedTimeAndDate() -> String {
+            let formatter: DateIntervalFormatter = DateFormatters.SessionCardView.shared.utcDateIntervalFormatter
+            guard let start = session.startTime else { return "" }
+            let end = session.endTime ?? stream.lastMeasurementTime ?? DateBuilder.getFakeUTCDate()
+            
+            let string = formatter.string(from: start, to: end)
+            return string
+        }
     }
 }

--- a/AirCasting/SessionViews/SessionTimeView.swift
+++ b/AirCasting/SessionViews/SessionTimeView.swift
@@ -4,7 +4,7 @@
 import Foundation
 import SwiftUI
 
-struct SessionTime: View {
+struct SessionTimeView: View {
     @ObservedObject var session: SessionEntity
     
     private var sessionStreams: [MeasurementStreamEntity] {


### PR DESCRIPTION
# What was the problem?
Turn out active session end time was updating only because the whole session card was updating when statistics were calculated, which was happening even if user was not in map/graph view. When we fixed excessive statistics updating, session end time stopped updating.

# What was done?
I added new DynamicSessionEndTime view for active sessions which observes stream and shows end time based on the last measurement time. It has to be done like that because before the session is finished it's end time is nil.

https://trello.com/c/t3GQHAVF