### PR TITLE
Auto navigate to mobile active 

### DIFF
--- a/AirCasting/SessionViews/SessionCardView.swift
+++ b/AirCasting/SessionViews/SessionCardView.swift
@@ -240,6 +240,7 @@ private extension SessionCardView {
                                   showLoadingIndicator: $showLoadingIndicator,
                                   selectedStream: $selectedStream)
             .foregroundColor(.aircastingDarkGray)
+            .onDisappear { isMapButtonActive = false }
 
          return NavigationLink(destination: mapView,
                                isActive: $isMapButtonActive,
@@ -255,6 +256,7 @@ private extension SessionCardView {
                                    statsContainerViewModel: graphStatsViewModel,
                                    graphStatsDataSource: graphStatsDataSource.dataSource)
              .foregroundColor(.aircastingDarkGray)
+             .onDisappear { isGraphButtonActive = false }
 
          return NavigationLink(destination: graphView,
                                isActive: $isGraphButtonActive,


### PR DESCRIPTION
https://trello.com/c/jolWIKyL/863-mobile-active-app-doesnt-auto-navigate-to-mobile-active-tab-after-starting-a-mobile-active-session