### PR TITLE
Refresh objects in the context before saving

### DIFF
--- a/AirCasting/CoreData/NSManagedObjectContext+Utils.swift
+++ b/AirCasting/CoreData/NSManagedObjectContext+Utils.swift
@@ -22,6 +22,7 @@ extension NSManagedObjectContext {
         req.predicate = NSPredicate(format: "time < %@ AND measurementStream == %@",
                                     NSDate(timeIntervalSince1970: thresholdInSeconds), stream)
         do {
+            self.refreshAllObjects()
             let measurements = try self.fetch(req)
             measurements.forEach { Log.info("Removing measurement for stream: \($0.measurementStream.sensorName ?? "no name") from \(String(describing: $0.time))"); self.delete($0) }
             try! self.save()


### PR DESCRIPTION
The change was made to fix a bug that was causing the app to crash during session averaging while the was a followed session.
https://trello.com/c/2uiHArCd