### PR TITLE
Rename settings - Clear SD to Clear AirBeam data storage.

### DIFF
--- a/AirCasting/Utils/Strings.swift
+++ b/AirCasting/Utils/Strings.swift
@@ -57,7 +57,7 @@ struct Strings {
                                                      comment: "")
         static let keepScreenTitle = NSLocalizedString("Keep screen on",
                                                        comment: "")
-        static let clearSDTitle = NSLocalizedString("Clear SD card",
+        static let clearSDTitle = NSLocalizedString("Clear AirBeam data storage",
                                                     comment: "")
         static let appInfoTitle = NSLocalizedString("AirCasting App v",
                                                     comment: "")


### PR DESCRIPTION
https://trello.com/c/HpN9VyAO/885-settings-clear-sd-card-update-text-so-it-reads-clear-airbeam-data-storage